### PR TITLE
Report

### DIFF
--- a/config
+++ b/config
@@ -1,0 +1,9 @@
+mysql-host=127.0.0.1
+mysql-port=4000
+mysql-user=root
+mysql-password=
+mysql-db=sbtest
+time=600
+threads=16
+report-interval=10
+db-driver=mysql

--- a/sysbench-reports/rvbox12-gcc-riscv64-linux-gnu.md
+++ b/sysbench-reports/rvbox12-gcc-riscv64-linux-gnu.md
@@ -1,0 +1,316 @@
+# RVBox12 gcc-riscv64-linux-gnu 编译器（默认参数）
+## 编译
+```shell
+$ GOOS=linux GOARCH=riscv64 CC=riscv64-linux-gnu-gcc make server
+```
+
+## 测试
+Point Select
+```shell
+hanbings@sophgo-farm-entrypoint:~$ ./sysbench --config-file=config oltp_point_select --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
+sysbench 1.1.0-de18a03 (using bundled LuaJIT 2.1.0-beta3)
+
+Running the test with following options:
+Number of threads: 16
+Report intermediate results every 10 second(s)
+Initializing random number generator from current time
+
+
+Initializing worker threads...
+
+Threads started!
+
+[ 10s ] thds: 16 tps: 202.66 qps: 202.66 (r/w/o: 202.66/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 20s ] thds: 16 tps: 197.30 qps: 197.30 (r/w/o: 197.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 30s ] thds: 16 tps: 196.80 qps: 196.80 (r/w/o: 196.80/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 40s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 198.40/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 50s ] thds: 16 tps: 196.80 qps: 196.80 (r/w/o: 196.80/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 60s ] thds: 16 tps: 198.30 qps: 198.30 (r/w/o: 198.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 70s ] thds: 16 tps: 196.90 qps: 196.90 (r/w/o: 196.90/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 80s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 198.40/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 90s ] thds: 16 tps: 196.80 qps: 196.80 (r/w/o: 196.80/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 100s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 198.40/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 110s ] thds: 16 tps: 198.20 qps: 198.20 (r/w/o: 198.20/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 120s ] thds: 16 tps: 197.00 qps: 197.00 (r/w/o: 197.00/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 130s ] thds: 16 tps: 198.20 qps: 198.20 (r/w/o: 198.20/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 140s ] thds: 16 tps: 197.00 qps: 197.00 (r/w/o: 197.00/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 150s ] thds: 16 tps: 198.20 qps: 198.20 (r/w/o: 198.20/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 160s ] thds: 16 tps: 197.00 qps: 197.00 (r/w/o: 197.00/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 170s ] thds: 16 tps: 198.20 qps: 198.20 (r/w/o: 198.20/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 180s ] thds: 16 tps: 197.00 qps: 197.00 (r/w/o: 197.00/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 190s ] thds: 16 tps: 198.20 qps: 198.20 (r/w/o: 198.20/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 200s ] thds: 16 tps: 197.00 qps: 197.00 (r/w/o: 197.00/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 210s ] thds: 16 tps: 196.80 qps: 196.80 (r/w/o: 196.80/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 220s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 198.40/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 230s ] thds: 16 tps: 196.80 qps: 196.80 (r/w/o: 196.80/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 240s ] thds: 16 tps: 204.80 qps: 204.80 (r/w/o: 204.80/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 250s ] thds: 16 tps: 196.80 qps: 196.80 (r/w/o: 196.80/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 260s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 198.40/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 270s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 198.40/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 280s ] thds: 16 tps: 197.00 qps: 197.00 (r/w/o: 197.00/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 290s ] thds: 16 tps: 198.30 qps: 198.30 (r/w/o: 198.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 300s ] thds: 16 tps: 198.30 qps: 198.30 (r/w/o: 198.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 310s ] thds: 16 tps: 197.00 qps: 197.00 (r/w/o: 197.00/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 320s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 198.40/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 330s ] thds: 16 tps: 198.30 qps: 198.30 (r/w/o: 198.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 340s ] thds: 16 tps: 198.20 qps: 198.20 (r/w/o: 198.20/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 350s ] thds: 16 tps: 197.10 qps: 197.10 (r/w/o: 197.10/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 360s ] thds: 16 tps: 198.30 qps: 198.30 (r/w/o: 198.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 370s ] thds: 16 tps: 198.00 qps: 198.00 (r/w/o: 198.00/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 380s ] thds: 16 tps: 197.30 qps: 197.30 (r/w/o: 197.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 390s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 198.40/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 400s ] thds: 16 tps: 198.30 qps: 198.30 (r/w/o: 198.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 410s ] thds: 16 tps: 198.00 qps: 198.00 (r/w/o: 198.00/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 420s ] thds: 16 tps: 197.30 qps: 197.30 (r/w/o: 197.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 430s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 198.40/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 440s ] thds: 16 tps: 198.30 qps: 198.30 (r/w/o: 198.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 450s ] thds: 16 tps: 198.10 qps: 198.10 (r/w/o: 198.10/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 460s ] thds: 16 tps: 198.30 qps: 198.30 (r/w/o: 198.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 470s ] thds: 16 tps: 197.30 qps: 197.30 (r/w/o: 197.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 480s ] thds: 16 tps: 198.30 qps: 198.30 (r/w/o: 198.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 490s ] thds: 16 tps: 198.00 qps: 198.00 (r/w/o: 198.00/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 500s ] thds: 16 tps: 197.30 qps: 197.30 (r/w/o: 197.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 510s ] thds: 16 tps: 198.30 qps: 198.30 (r/w/o: 198.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 520s ] thds: 16 tps: 198.00 qps: 198.00 (r/w/o: 198.00/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 530s ] thds: 16 tps: 197.30 qps: 197.30 (r/w/o: 197.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 540s ] thds: 16 tps: 198.30 qps: 198.30 (r/w/o: 198.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 550s ] thds: 16 tps: 198.00 qps: 198.00 (r/w/o: 198.00/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 560s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 198.40/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 570s ] thds: 16 tps: 197.20 qps: 197.20 (r/w/o: 197.20/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 580s ] thds: 16 tps: 198.00 qps: 198.00 (r/w/o: 198.00/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 590s ] thds: 16 tps: 197.30 qps: 197.30 (r/w/o: 197.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 600s ] thds: 16 tps: 198.30 qps: 198.30 (r/w/o: 198.30/0.00/0.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+SQL statistics:
+    queries performed:
+        read:                            118801
+        write:                           0
+        other:                           0
+        total:                           118801
+    transactions:                        118801 (197.98 per sec.)
+    queries:                             118801 (197.98 per sec.)
+    ignored errors:                      0      (0.00 per sec.)
+    reconnects:                          0      (0.00 per sec.)
+
+Throughput:
+    events/s (eps):                      197.9794
+    time elapsed:                        600.0676s
+    total number of events:              118801
+
+Latency (ms):
+         min:                                   53.88
+         avg:                                   80.81
+         max:                                  116.93
+         95th percentile:                       81.48
+         sum:                              9600623.17
+
+Threads fairness:
+    events (avg/stddev):           7425.0625/0.24
+    execution time (avg/stddev):   600.0389/0.01
+```
+
+Update Index
+```shell
+hanbings@sophgo-farm-entrypoint:~$ ./sysbench --config-file=config oltp_update_index --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
+sysbench 1.1.0-de18a03 (using bundled LuaJIT 2.1.0-beta3)
+
+Running the test with following options:
+Number of threads: 16
+Report intermediate results every 10 second(s)
+Initializing random number generator from current time
+
+
+Initializing worker threads...
+
+Threads started!
+
+[ 10s ] thds: 16 tps: 225.65 qps: 225.65 (r/w/o: 0.00/222.66/3.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 20s ] thds: 16 tps: 198.31 qps: 198.31 (r/w/o: 0.00/195.31/3.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 30s ] thds: 16 tps: 197.00 qps: 197.00 (r/w/o: 0.00/194.90/2.10) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 40s ] thds: 16 tps: 199.80 qps: 199.80 (r/w/o: 0.00/197.30/2.50) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 50s ] thds: 16 tps: 197.00 qps: 197.00 (r/w/o: 0.00/193.70/3.30) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 60s ] thds: 16 tps: 198.30 qps: 198.30 (r/w/o: 0.00/195.20/3.10) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 70s ] thds: 16 tps: 198.30 qps: 198.30 (r/w/o: 0.00/195.50/2.80) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 80s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/195.70/2.70) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 90s ] thds: 16 tps: 197.00 qps: 197.00 (r/w/o: 0.00/194.20/2.80) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 100s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/196.00/2.40) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 110s ] thds: 16 tps: 197.70 qps: 197.70 (r/w/o: 0.00/195.80/1.90) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 120s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/196.20/2.20) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 130s ] thds: 16 tps: 197.60 qps: 197.60 (r/w/o: 0.00/194.40/3.20) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 140s ] thds: 16 tps: 197.60 qps: 197.60 (r/w/o: 0.00/194.80/2.80) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 150s ] thds: 16 tps: 198.20 qps: 198.20 (r/w/o: 0.00/194.90/3.30) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 160s ] thds: 16 tps: 198.50 qps: 198.50 (r/w/o: 0.00/196.00/2.50) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 170s ] thds: 16 tps: 198.30 qps: 198.30 (r/w/o: 0.00/194.30/4.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 180s ] thds: 16 tps: 198.50 qps: 198.50 (r/w/o: 0.00/195.40/3.10) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 190s ] thds: 16 tps: 199.20 qps: 199.20 (r/w/o: 0.00/196.60/2.60) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 200s ] thds: 16 tps: 199.10 qps: 199.10 (r/w/o: 0.00/196.50/2.60) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 210s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/195.00/3.40) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 220s ] thds: 16 tps: 197.70 qps: 197.70 (r/w/o: 0.00/194.80/2.90) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 230s ] thds: 16 tps: 197.60 qps: 197.60 (r/w/o: 0.00/194.60/3.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 240s ] thds: 16 tps: 198.30 qps: 198.30 (r/w/o: 0.00/195.10/3.20) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 250s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/195.30/3.10) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 260s ] thds: 16 tps: 197.70 qps: 197.70 (r/w/o: 0.00/194.60/3.10) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 270s ] thds: 16 tps: 197.60 qps: 197.60 (r/w/o: 0.00/194.30/3.30) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 280s ] thds: 16 tps: 199.20 qps: 199.20 (r/w/o: 0.00/196.00/3.20) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 290s ] thds: 16 tps: 197.60 qps: 197.60 (r/w/o: 0.00/194.80/2.80) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 300s ] thds: 16 tps: 198.30 qps: 198.30 (r/w/o: 0.00/195.00/3.30) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 310s ] thds: 16 tps: 197.50 qps: 197.50 (r/w/o: 0.00/195.80/1.70) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 320s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/195.40/3.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 330s ] thds: 16 tps: 197.80 qps: 197.80 (r/w/o: 0.00/194.00/3.80) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 340s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/195.00/3.40) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 350s ] thds: 16 tps: 197.20 qps: 197.20 (r/w/o: 0.00/194.40/2.80) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 360s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/195.10/3.30) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 370s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/195.30/3.10) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 380s ] thds: 16 tps: 196.90 qps: 196.90 (r/w/o: 0.00/195.40/1.50) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 390s ] thds: 16 tps: 197.70 qps: 197.70 (r/w/o: 0.00/194.30/3.40) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 400s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/194.60/3.80) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 410s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/195.30/3.10) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 420s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/195.70/2.70) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 430s ] thds: 16 tps: 198.20 qps: 198.20 (r/w/o: 0.00/195.10/3.10) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 440s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/195.40/3.00) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 450s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/194.70/3.70) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 460s ] thds: 16 tps: 197.40 qps: 197.40 (r/w/o: 0.00/195.20/2.20) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 470s ] thds: 16 tps: 198.00 qps: 198.00 (r/w/o: 0.00/195.90/2.10) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 480s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/195.50/2.90) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 490s ] thds: 16 tps: 197.90 qps: 197.90 (r/w/o: 0.00/194.20/3.70) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 500s ] thds: 16 tps: 197.70 qps: 197.70 (r/w/o: 0.00/194.80/2.90) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 510s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/195.80/2.60) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 520s ] thds: 16 tps: 198.00 qps: 198.00 (r/w/o: 0.00/195.70/2.30) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 530s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/195.10/3.30) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 540s ] thds: 16 tps: 209.30 qps: 209.30 (r/w/o: 0.00/206.60/2.70) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 550s ] thds: 16 tps: 198.20 qps: 198.20 (r/w/o: 0.00/194.90/3.30) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 560s ] thds: 16 tps: 197.50 qps: 197.50 (r/w/o: 0.00/195.40/2.10) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 570s ] thds: 16 tps: 199.20 qps: 199.20 (r/w/o: 0.00/196.70/2.50) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 580s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/195.90/2.50) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 590s ] thds: 16 tps: 197.60 qps: 197.60 (r/w/o: 0.00/195.20/2.40) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+[ 600s ] thds: 16 tps: 198.40 qps: 198.40 (r/w/o: 0.00/195.50/2.90) lat (ms,95%): 81.48 err/s: 0.00 reconn/s: 0.00
+SQL statistics:
+    queries performed:
+        read:                            0
+        write:                           117544
+        other:                           1730
+        total:                           119274
+    transactions:                        119274 (198.77 per sec.)
+    queries:                             119274 (198.77 per sec.)
+    ignored errors:                      0      (0.00 per sec.)
+    reconnects:                          0      (0.00 per sec.)
+
+Throughput:
+    events/s (eps):                      198.7684
+    time elapsed:                        600.0652s
+    total number of events:              119274
+
+Latency (ms):
+         min:                                   33.52
+         avg:                                   80.49
+         max:                                  219.21
+         95th percentile:                       81.48
+         sum:                              9600401.91
+
+Threads fairness:
+    events (avg/stddev):           7454.6250/0.93
+    execution time (avg/stddev):   600.0251/0.02
+```
+
+Read Only
+```shell
+hanbings@sophgo-farm-entrypoint:~$ ./sysbench --config-file=config oltp_read_only --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
+sysbench 1.1.0-de18a03 (using bundled LuaJIT 2.1.0-beta3)
+
+Running the test with following options:
+Number of threads: 16
+Report intermediate results every 10 second(s)
+Initializing random number generator from current time
+
+
+Initializing worker threads...
+
+Threads started!
+
+[ 10s ] thds: 16 tps: 11.80 qps: 204.06 (r/w/o: 179.36/0.00/24.69) lat (ms,95%): 1327.91 err/s: 0.00 reconn/s: 0.00
+[ 20s ] thds: 16 tps: 12.30 qps: 202.21 (r/w/o: 177.11/0.00/25.10) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 30s ] thds: 16 tps: 12.80 qps: 202.30 (r/w/o: 176.70/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 40s ] thds: 16 tps: 12.80 qps: 200.90 (r/w/o: 175.30/0.00/25.60) lat (ms,95%): 1327.91 err/s: 0.00 reconn/s: 0.00
+[ 50s ] thds: 16 tps: 12.80 qps: 200.70 (r/w/o: 175.10/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 60s ] thds: 16 tps: 12.80 qps: 197.60 (r/w/o: 172.00/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 70s ] thds: 16 tps: 11.30 qps: 198.30 (r/w/o: 175.80/0.00/22.50) lat (ms,95%): 1327.91 err/s: 0.00 reconn/s: 0.00
+[ 80s ] thds: 16 tps: 12.70 qps: 203.80 (r/w/o: 178.30/0.00/25.50) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 90s ] thds: 16 tps: 12.80 qps: 202.70 (r/w/o: 177.10/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 100s ] thds: 16 tps: 12.80 qps: 209.10 (r/w/o: 183.50/0.00/25.60) lat (ms,95%): 1280.93 err/s: 0.00 reconn/s: 0.00
+[ 110s ] thds: 16 tps: 12.80 qps: 198.80 (r/w/o: 173.20/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 120s ] thds: 16 tps: 12.80 qps: 201.90 (r/w/o: 176.30/0.00/25.60) lat (ms,95%): 1327.91 err/s: 0.00 reconn/s: 0.00
+[ 130s ] thds: 16 tps: 12.90 qps: 205.90 (r/w/o: 180.20/0.00/25.70) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 140s ] thds: 16 tps: 12.80 qps: 204.10 (r/w/o: 178.40/0.00/25.70) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 150s ] thds: 16 tps: 12.80 qps: 202.30 (r/w/o: 176.70/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 160s ] thds: 16 tps: 12.80 qps: 203.20 (r/w/o: 177.60/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 170s ] thds: 16 tps: 12.80 qps: 201.70 (r/w/o: 176.10/0.00/25.60) lat (ms,95%): 1352.03 err/s: 0.00 reconn/s: 0.00
+[ 180s ] thds: 16 tps: 12.80 qps: 205.80 (r/w/o: 180.20/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 190s ] thds: 16 tps: 12.80 qps: 203.00 (r/w/o: 177.40/0.00/25.60) lat (ms,95%): 1327.91 err/s: 0.00 reconn/s: 0.00
+[ 200s ] thds: 16 tps: 12.90 qps: 203.60 (r/w/o: 177.80/0.00/25.80) lat (ms,95%): 1327.91 err/s: 0.00 reconn/s: 0.00
+[ 210s ] thds: 16 tps: 12.80 qps: 202.90 (r/w/o: 178.50/0.00/24.40) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 220s ] thds: 16 tps: 12.10 qps: 204.40 (r/w/o: 179.40/0.00/25.00) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 230s ] thds: 16 tps: 13.10 qps: 205.30 (r/w/o: 179.60/0.00/25.70) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 240s ] thds: 16 tps: 11.80 qps: 202.00 (r/w/o: 177.50/0.00/24.50) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 250s ] thds: 16 tps: 12.70 qps: 198.90 (r/w/o: 173.50/0.00/25.40) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 260s ] thds: 16 tps: 12.80 qps: 199.90 (r/w/o: 174.30/0.00/25.60) lat (ms,95%): 1327.91 err/s: 0.00 reconn/s: 0.00
+[ 270s ] thds: 16 tps: 12.80 qps: 202.10 (r/w/o: 176.50/0.00/25.60) lat (ms,95%): 1327.91 err/s: 0.00 reconn/s: 0.00
+[ 280s ] thds: 16 tps: 12.80 qps: 200.00 (r/w/o: 174.40/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 290s ] thds: 16 tps: 12.10 qps: 201.60 (r/w/o: 177.90/0.00/23.70) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 300s ] thds: 16 tps: 12.10 qps: 203.70 (r/w/o: 179.00/0.00/24.70) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 310s ] thds: 16 tps: 13.40 qps: 206.50 (r/w/o: 180.30/0.00/26.20) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 320s ] thds: 16 tps: 12.20 qps: 201.40 (r/w/o: 176.40/0.00/25.00) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 330s ] thds: 16 tps: 12.80 qps: 201.80 (r/w/o: 176.20/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 340s ] thds: 16 tps: 12.80 qps: 205.00 (r/w/o: 179.40/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 350s ] thds: 16 tps: 12.80 qps: 204.40 (r/w/o: 178.80/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 360s ] thds: 16 tps: 12.80 qps: 203.10 (r/w/o: 177.50/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 370s ] thds: 16 tps: 12.90 qps: 205.30 (r/w/o: 179.50/0.00/25.80) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 380s ] thds: 16 tps: 12.80 qps: 204.80 (r/w/o: 179.20/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 390s ] thds: 16 tps: 12.80 qps: 204.00 (r/w/o: 178.40/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 400s ] thds: 16 tps: 12.80 qps: 201.90 (r/w/o: 176.30/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 410s ] thds: 16 tps: 12.80 qps: 197.40 (r/w/o: 171.80/0.00/25.60) lat (ms,95%): 1327.91 err/s: 0.00 reconn/s: 0.00
+[ 420s ] thds: 16 tps: 12.80 qps: 203.00 (r/w/o: 178.20/0.00/24.80) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 430s ] thds: 16 tps: 11.30 qps: 201.60 (r/w/o: 178.30/0.00/23.30) lat (ms,95%): 1352.03 err/s: 0.00 reconn/s: 0.00
+[ 440s ] thds: 16 tps: 12.80 qps: 202.60 (r/w/o: 177.00/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 450s ] thds: 16 tps: 12.70 qps: 200.80 (r/w/o: 175.30/0.00/25.50) lat (ms,95%): 1327.91 err/s: 0.00 reconn/s: 0.00
+[ 460s ] thds: 16 tps: 12.90 qps: 209.60 (r/w/o: 183.90/0.00/25.70) lat (ms,95%): 1327.91 err/s: 0.00 reconn/s: 0.00
+[ 470s ] thds: 16 tps: 12.70 qps: 203.50 (r/w/o: 178.00/0.00/25.50) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 480s ] thds: 16 tps: 12.80 qps: 196.90 (r/w/o: 171.30/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 490s ] thds: 16 tps: 12.80 qps: 194.60 (r/w/o: 169.10/0.00/25.50) lat (ms,95%): 1327.91 err/s: 0.00 reconn/s: 0.00
+[ 500s ] thds: 16 tps: 11.20 qps: 197.00 (r/w/o: 174.50/0.00/22.50) lat (ms,95%): 1327.91 err/s: 0.00 reconn/s: 0.00
+[ 510s ] thds: 16 tps: 12.90 qps: 204.10 (r/w/o: 178.30/0.00/25.80) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 520s ] thds: 16 tps: 12.80 qps: 201.60 (r/w/o: 176.00/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 530s ] thds: 16 tps: 12.80 qps: 204.10 (r/w/o: 178.50/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 540s ] thds: 16 tps: 12.80 qps: 200.30 (r/w/o: 174.70/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 550s ] thds: 16 tps: 12.20 qps: 195.10 (r/w/o: 171.10/0.00/24.00) lat (ms,95%): 1327.91 err/s: 0.00 reconn/s: 0.00
+[ 560s ] thds: 16 tps: 11.80 qps: 196.00 (r/w/o: 172.00/0.00/24.00) lat (ms,95%): 1327.91 err/s: 0.00 reconn/s: 0.00
+[ 570s ] thds: 16 tps: 12.80 qps: 203.60 (r/w/o: 178.00/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 580s ] thds: 16 tps: 12.80 qps: 202.00 (r/w/o: 176.40/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 590s ] thds: 16 tps: 12.80 qps: 201.80 (r/w/o: 176.20/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+[ 600s ] thds: 16 tps: 12.80 qps: 202.30 (r/w/o: 176.70/0.00/25.60) lat (ms,95%): 1304.21 err/s: 0.00 reconn/s: 0.00
+SQL statistics:
+    queries performed:
+        read:                            106288
+        write:                           0
+        other:                           15184
+        total:                           121472
+    transactions:                        7592   (12.63 per sec.)
+    queries:                             121472 (202.12 per sec.)
+    ignored errors:                      0      (0.00 per sec.)
+    reconnects:                          0      (0.00 per sec.)
+
+Throughput:
+    events/s (eps):                      12.6327
+    time elapsed:                        600.9789s
+    total number of events:              7592
+
+Latency (ms):
+         min:                                  909.25
+         avg:                                 1266.35
+         max:                                 1394.78
+         95th percentile:                     1304.21
+         sum:                              9614119.40
+
+Threads fairness:
+    events (avg/stddev):           474.5000/1.46
+    execution time (avg/stddev):   600.8825/0.21
+
+```

--- a/sysbench-reports/rvbox13-Xuantie-900-gcc-linux-6.6.0-glibc-x86_64-V2.10.1-rv64imafdcv0p7_zfh_xtheadc.md
+++ b/sysbench-reports/rvbox13-Xuantie-900-gcc-linux-6.6.0-glibc-x86_64-V2.10.1-rv64imafdcv0p7_zfh_xtheadc.md
@@ -1,0 +1,316 @@
+# RVBox13 Xuantie-900-gcc-linux-6.6.0-glibc-x86_64-V2.10.1 编译器（rv64imafdcv0p7_zfh_xtheadc）
+## 编译
+请注意替换 CC 的路径
+```shell
+$ CGO_CFLAGS=-march=rv64imafdcv0p7_zfh_xtheadc GOOS=linux GOARCH=riscv64 CC=/opt/Xuantie-900-gcc-linux-6.6.0-glibc-x86_64-V2.10.1/bin/riscv64-unknown-linux-gnu-gcc make server
+```
+
+## 测试
+Point Select
+```shell
+hanbings@sophgo-farm-entrypoint:~$ ./sysbench --config-file=config oltp_point_select --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
+sysbench 1.1.0-de18a03 (using bundled LuaJIT 2.1.0-beta3)
+
+Running the test with following options:
+Number of threads: 16
+Report intermediate results every 10 second(s)
+Initializing random number generator from current time
+
+
+Initializing worker threads...
+
+Threads started!
+
+[ 10s ] thds: 16 tps: 1726.98 qps: 1726.98 (r/w/o: 1726.98/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 20s ] thds: 16 tps: 1712.01 qps: 1712.01 (r/w/o: 1712.01/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 30s ] thds: 16 tps: 1698.20 qps: 1698.20 (r/w/o: 1698.20/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 40s ] thds: 16 tps: 1703.30 qps: 1703.30 (r/w/o: 1703.30/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 50s ] thds: 16 tps: 1700.40 qps: 1700.40 (r/w/o: 1700.40/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 60s ] thds: 16 tps: 1724.19 qps: 1724.19 (r/w/o: 1724.19/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 70s ] thds: 16 tps: 1708.91 qps: 1708.91 (r/w/o: 1708.91/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 80s ] thds: 16 tps: 1707.50 qps: 1707.50 (r/w/o: 1707.50/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 90s ] thds: 16 tps: 1707.80 qps: 1707.80 (r/w/o: 1707.80/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 100s ] thds: 16 tps: 1721.19 qps: 1721.19 (r/w/o: 1721.19/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 110s ] thds: 16 tps: 1661.00 qps: 1661.00 (r/w/o: 1661.00/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 120s ] thds: 16 tps: 1718.61 qps: 1718.61 (r/w/o: 1718.61/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 130s ] thds: 16 tps: 1711.80 qps: 1711.80 (r/w/o: 1711.80/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 140s ] thds: 16 tps: 1721.30 qps: 1721.30 (r/w/o: 1721.30/0.00/0.00) lat (ms,95%): 10.27 err/s: 0.00 reconn/s: 0.00
+[ 150s ] thds: 16 tps: 1634.69 qps: 1634.69 (r/w/o: 1634.69/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 160s ] thds: 16 tps: 1720.22 qps: 1720.22 (r/w/o: 1720.22/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 170s ] thds: 16 tps: 1694.00 qps: 1694.00 (r/w/o: 1694.00/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 180s ] thds: 16 tps: 1702.40 qps: 1702.40 (r/w/o: 1702.40/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 190s ] thds: 16 tps: 1718.39 qps: 1718.39 (r/w/o: 1718.39/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 200s ] thds: 16 tps: 1699.31 qps: 1699.31 (r/w/o: 1699.31/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 210s ] thds: 16 tps: 1711.39 qps: 1711.39 (r/w/o: 1711.39/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 220s ] thds: 16 tps: 1714.01 qps: 1714.01 (r/w/o: 1714.01/0.00/0.00) lat (ms,95%): 10.27 err/s: 0.00 reconn/s: 0.00
+[ 230s ] thds: 16 tps: 1719.30 qps: 1719.30 (r/w/o: 1719.30/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 240s ] thds: 16 tps: 1738.10 qps: 1738.10 (r/w/o: 1738.10/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 250s ] thds: 16 tps: 1722.40 qps: 1722.40 (r/w/o: 1722.40/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 260s ] thds: 16 tps: 1714.30 qps: 1714.30 (r/w/o: 1714.30/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 270s ] thds: 16 tps: 1723.90 qps: 1723.90 (r/w/o: 1723.90/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 280s ] thds: 16 tps: 1717.70 qps: 1717.70 (r/w/o: 1717.70/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 290s ] thds: 16 tps: 1729.50 qps: 1729.50 (r/w/o: 1729.50/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 300s ] thds: 16 tps: 1708.60 qps: 1708.60 (r/w/o: 1708.60/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 310s ] thds: 16 tps: 1731.11 qps: 1731.11 (r/w/o: 1731.11/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 320s ] thds: 16 tps: 1727.60 qps: 1727.60 (r/w/o: 1727.60/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 330s ] thds: 16 tps: 1712.20 qps: 1712.20 (r/w/o: 1712.20/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 340s ] thds: 16 tps: 1717.20 qps: 1717.20 (r/w/o: 1717.20/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 350s ] thds: 16 tps: 1719.89 qps: 1719.89 (r/w/o: 1719.89/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 360s ] thds: 16 tps: 1711.31 qps: 1711.31 (r/w/o: 1711.31/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 370s ] thds: 16 tps: 1717.30 qps: 1717.30 (r/w/o: 1717.30/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 380s ] thds: 16 tps: 1719.70 qps: 1719.70 (r/w/o: 1719.70/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 390s ] thds: 16 tps: 1715.40 qps: 1715.40 (r/w/o: 1715.40/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 400s ] thds: 16 tps: 1720.40 qps: 1720.40 (r/w/o: 1720.40/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 410s ] thds: 16 tps: 1698.59 qps: 1698.59 (r/w/o: 1698.59/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 420s ] thds: 16 tps: 1715.01 qps: 1715.01 (r/w/o: 1715.01/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 430s ] thds: 16 tps: 1708.30 qps: 1708.30 (r/w/o: 1708.30/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 440s ] thds: 16 tps: 1715.69 qps: 1715.69 (r/w/o: 1715.69/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 450s ] thds: 16 tps: 1717.31 qps: 1717.31 (r/w/o: 1717.31/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 460s ] thds: 16 tps: 1717.11 qps: 1717.11 (r/w/o: 1717.11/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 470s ] thds: 16 tps: 1729.10 qps: 1729.10 (r/w/o: 1729.10/0.00/0.00) lat (ms,95%): 10.27 err/s: 0.00 reconn/s: 0.00
+[ 480s ] thds: 16 tps: 1713.30 qps: 1713.30 (r/w/o: 1713.30/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 490s ] thds: 16 tps: 1718.40 qps: 1718.40 (r/w/o: 1718.40/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 500s ] thds: 16 tps: 1727.80 qps: 1727.80 (r/w/o: 1727.80/0.00/0.00) lat (ms,95%): 10.27 err/s: 0.00 reconn/s: 0.00
+[ 510s ] thds: 16 tps: 1732.20 qps: 1732.20 (r/w/o: 1732.20/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 520s ] thds: 16 tps: 1700.90 qps: 1700.90 (r/w/o: 1700.90/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 530s ] thds: 16 tps: 1711.80 qps: 1711.80 (r/w/o: 1711.80/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 540s ] thds: 16 tps: 1712.01 qps: 1712.01 (r/w/o: 1712.01/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 550s ] thds: 16 tps: 1720.79 qps: 1720.79 (r/w/o: 1720.79/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 560s ] thds: 16 tps: 1736.31 qps: 1736.31 (r/w/o: 1736.31/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 570s ] thds: 16 tps: 1728.11 qps: 1728.11 (r/w/o: 1728.11/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 580s ] thds: 16 tps: 1719.39 qps: 1719.39 (r/w/o: 1719.39/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 590s ] thds: 16 tps: 1730.80 qps: 1730.80 (r/w/o: 1730.80/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 600s ] thds: 16 tps: 1713.33 qps: 1713.33 (r/w/o: 1713.33/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+SQL statistics:
+    queries performed:
+        read:                            1028516
+        write:                           0
+        other:                           0
+        total:                           1028516
+    transactions:                        1028516 (1714.17 per sec.)
+    queries:                             1028516 (1714.17 per sec.)
+    ignored errors:                      0      (0.00 per sec.)
+    reconnects:                          0      (0.00 per sec.)
+
+Throughput:
+    events/s (eps):                      1714.1689
+    time elapsed:                        600.0085s
+    total number of events:              1028516
+
+Latency (ms):
+         min:                                    5.11
+         avg:                                    9.33
+         max:                                  232.14
+         95th percentile:                       10.65
+         sum:                              9599491.76
+
+Threads fairness:
+    events (avg/stddev):           64282.2500/6335.42
+    execution time (avg/stddev):   599.9682/0.02
+```
+
+Update Index
+```shell
+hanbings@sophgo-farm-entrypoint:~$ ./sysbench --config-file=config oltp_update_index --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
+sysbench 1.1.0-de18a03 (using bundled LuaJIT 2.1.0-beta3)
+
+Running the test with following options:
+Number of threads: 16
+Report intermediate results every 10 second(s)
+Initializing random number generator from current time
+
+
+Initializing worker threads...
+
+Threads started!
+
+[ 10s ] thds: 16 tps: 1552.93 qps: 1552.93 (r/w/o: 0.00/1528.73/24.20) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 20s ] thds: 16 tps: 1540.60 qps: 1540.60 (r/w/o: 0.00/1519.40/21.20) lat (ms,95%): 11.45 err/s: 0.00 reconn/s: 0.00
+[ 30s ] thds: 16 tps: 1506.80 qps: 1506.80 (r/w/o: 0.00/1486.10/20.70) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 40s ] thds: 16 tps: 1555.00 qps: 1555.00 (r/w/o: 0.00/1529.00/26.00) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 50s ] thds: 16 tps: 1538.89 qps: 1538.89 (r/w/o: 0.00/1516.29/22.60) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 60s ] thds: 16 tps: 1540.01 qps: 1540.01 (r/w/o: 0.00/1518.81/21.20) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 70s ] thds: 16 tps: 1501.80 qps: 1501.80 (r/w/o: 0.00/1480.40/21.40) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 80s ] thds: 16 tps: 1538.11 qps: 1538.11 (r/w/o: 0.00/1516.11/22.00) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 90s ] thds: 16 tps: 1561.80 qps: 1561.80 (r/w/o: 0.00/1538.40/23.40) lat (ms,95%): 11.87 err/s: 0.00 reconn/s: 0.00
+[ 100s ] thds: 16 tps: 1539.90 qps: 1539.90 (r/w/o: 0.00/1517.30/22.60) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+[ 110s ] thds: 16 tps: 1506.09 qps: 1506.09 (r/w/o: 0.00/1483.89/22.20) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 120s ] thds: 16 tps: 1524.11 qps: 1524.11 (r/w/o: 0.00/1504.31/19.80) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 130s ] thds: 16 tps: 1537.39 qps: 1537.39 (r/w/o: 0.00/1515.09/22.30) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 140s ] thds: 16 tps: 1531.31 qps: 1531.31 (r/w/o: 0.00/1509.91/21.40) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 150s ] thds: 16 tps: 1479.90 qps: 1479.90 (r/w/o: 0.00/1458.30/21.60) lat (ms,95%): 13.22 err/s: 0.00 reconn/s: 0.00
+[ 160s ] thds: 16 tps: 1497.20 qps: 1497.20 (r/w/o: 0.00/1476.10/21.10) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 170s ] thds: 16 tps: 1501.10 qps: 1501.10 (r/w/o: 0.00/1480.70/20.40) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 180s ] thds: 16 tps: 1513.70 qps: 1513.70 (r/w/o: 0.00/1488.80/24.90) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 190s ] thds: 16 tps: 1542.60 qps: 1542.60 (r/w/o: 0.00/1521.10/21.50) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 200s ] thds: 16 tps: 1536.00 qps: 1536.00 (r/w/o: 0.00/1517.00/19.00) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+[ 210s ] thds: 16 tps: 1552.80 qps: 1552.80 (r/w/o: 0.00/1532.60/20.20) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 220s ] thds: 16 tps: 1513.70 qps: 1513.70 (r/w/o: 0.00/1491.70/22.00) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 230s ] thds: 16 tps: 1509.90 qps: 1509.90 (r/w/o: 0.00/1490.50/19.40) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 240s ] thds: 16 tps: 1442.70 qps: 1442.70 (r/w/o: 0.00/1421.20/21.50) lat (ms,95%): 13.22 err/s: 0.00 reconn/s: 0.00
+[ 250s ] thds: 16 tps: 1588.20 qps: 1588.20 (r/w/o: 0.00/1566.10/22.10) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 260s ] thds: 16 tps: 1590.49 qps: 1590.49 (r/w/o: 0.00/1568.39/22.10) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 270s ] thds: 16 tps: 1574.61 qps: 1574.61 (r/w/o: 0.00/1554.71/19.90) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 280s ] thds: 16 tps: 1552.89 qps: 1552.89 (r/w/o: 0.00/1532.39/20.50) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 290s ] thds: 16 tps: 1514.71 qps: 1514.71 (r/w/o: 0.00/1490.91/23.80) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 300s ] thds: 16 tps: 1516.90 qps: 1516.90 (r/w/o: 0.00/1497.20/19.70) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 310s ] thds: 16 tps: 1538.80 qps: 1538.80 (r/w/o: 0.00/1517.50/21.30) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 320s ] thds: 16 tps: 1548.70 qps: 1548.70 (r/w/o: 0.00/1526.60/22.10) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 330s ] thds: 16 tps: 1551.90 qps: 1551.90 (r/w/o: 0.00/1530.20/21.70) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 340s ] thds: 16 tps: 1550.19 qps: 1550.19 (r/w/o: 0.00/1530.09/20.10) lat (ms,95%): 11.87 err/s: 0.00 reconn/s: 0.00
+[ 350s ] thds: 16 tps: 1523.70 qps: 1523.70 (r/w/o: 0.00/1501.70/22.00) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 360s ] thds: 16 tps: 1587.09 qps: 1587.09 (r/w/o: 0.00/1564.49/22.60) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 370s ] thds: 16 tps: 1591.30 qps: 1591.30 (r/w/o: 0.00/1568.60/22.70) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 380s ] thds: 16 tps: 1573.11 qps: 1573.11 (r/w/o: 0.00/1550.61/22.50) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 390s ] thds: 16 tps: 1537.30 qps: 1537.30 (r/w/o: 0.00/1517.40/19.90) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 400s ] thds: 16 tps: 1533.89 qps: 1533.89 (r/w/o: 0.00/1512.09/21.80) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 410s ] thds: 16 tps: 1548.71 qps: 1548.71 (r/w/o: 0.00/1525.21/23.50) lat (ms,95%): 11.45 err/s: 0.00 reconn/s: 0.00
+[ 420s ] thds: 16 tps: 1538.20 qps: 1538.20 (r/w/o: 0.00/1516.40/21.80) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 430s ] thds: 16 tps: 1523.19 qps: 1523.19 (r/w/o: 0.00/1500.59/22.60) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 440s ] thds: 16 tps: 1545.51 qps: 1545.51 (r/w/o: 0.00/1524.81/20.70) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 450s ] thds: 16 tps: 1540.50 qps: 1540.50 (r/w/o: 0.00/1517.60/22.90) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 460s ] thds: 16 tps: 1560.69 qps: 1560.69 (r/w/o: 0.00/1540.49/20.20) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 470s ] thds: 16 tps: 1519.71 qps: 1519.71 (r/w/o: 0.00/1498.81/20.90) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 480s ] thds: 16 tps: 1548.29 qps: 1548.29 (r/w/o: 0.00/1528.69/19.60) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 490s ] thds: 16 tps: 1549.60 qps: 1549.60 (r/w/o: 0.00/1524.70/24.90) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 500s ] thds: 16 tps: 1550.00 qps: 1550.00 (r/w/o: 0.00/1526.60/23.40) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 510s ] thds: 16 tps: 1573.00 qps: 1573.00 (r/w/o: 0.00/1552.70/20.30) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 520s ] thds: 16 tps: 1551.09 qps: 1551.09 (r/w/o: 0.00/1527.69/23.40) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+[ 530s ] thds: 16 tps: 1535.00 qps: 1535.00 (r/w/o: 0.00/1509.30/25.70) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 540s ] thds: 16 tps: 1519.00 qps: 1519.00 (r/w/o: 0.00/1496.50/22.50) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 550s ] thds: 16 tps: 1519.60 qps: 1519.60 (r/w/o: 0.00/1499.20/20.40) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 560s ] thds: 16 tps: 1557.10 qps: 1557.10 (r/w/o: 0.00/1533.90/23.20) lat (ms,95%): 11.45 err/s: 0.00 reconn/s: 0.00
+[ 570s ] thds: 16 tps: 1526.49 qps: 1526.49 (r/w/o: 0.00/1502.19/24.30) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 580s ] thds: 16 tps: 1515.71 qps: 1515.71 (r/w/o: 0.00/1490.61/25.10) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 590s ] thds: 16 tps: 1550.50 qps: 1550.50 (r/w/o: 0.00/1528.80/21.70) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 600s ] thds: 16 tps: 1551.20 qps: 1551.20 (r/w/o: 0.00/1527.60/23.60) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+SQL statistics:
+    queries performed:
+        read:                            0
+        write:                           909450
+        other:                           13181
+        total:                           922631
+    transactions:                        922631 (1537.69 per sec.)
+    queries:                             922631 (1537.69 per sec.)
+    ignored errors:                      0      (0.00 per sec.)
+    reconnects:                          0      (0.00 per sec.)
+
+Throughput:
+    events/s (eps):                      1537.6895
+    time elapsed:                        600.0112s
+    total number of events:              922631
+
+Latency (ms):
+         min:                                    5.06
+         avg:                                   10.40
+         max:                                  253.81
+         95th percentile:                       12.52
+         sum:                              9599609.70
+
+Threads fairness:
+    events (avg/stddev):           57664.4375/373.62
+    execution time (avg/stddev):   599.9756/0.01
+```
+
+Read Only
+```shell
+hanbings@sophgo-farm-entrypoint:~$ ./sysbench --config-file=config oltp_read_only --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
+sysbench 1.1.0-de18a03 (using bundled LuaJIT 2.1.0-beta3)
+
+Running the test with following options:
+Number of threads: 16
+Report intermediate results every 10 second(s)
+Initializing random number generator from current time
+
+
+Initializing worker threads...
+
+Threads started!
+
+[ 10s ] thds: 16 tps: 89.68 qps: 1447.11 (r/w/o: 1266.24/0.00/180.86) lat (ms,95%): 267.41 err/s: 0.00 reconn/s: 0.00
+[ 20s ] thds: 16 tps: 100.10 qps: 1601.43 (r/w/o: 1401.13/0.00/200.30) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 30s ] thds: 16 tps: 90.70 qps: 1448.61 (r/w/o: 1267.41/0.00/181.20) lat (ms,95%): 196.89 err/s: 0.00 reconn/s: 0.00
+[ 40s ] thds: 16 tps: 100.20 qps: 1603.90 (r/w/o: 1403.60/0.00/200.30) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 50s ] thds: 16 tps: 98.50 qps: 1578.20 (r/w/o: 1381.00/0.00/197.20) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 60s ] thds: 16 tps: 98.10 qps: 1572.30 (r/w/o: 1376.00/0.00/196.30) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 70s ] thds: 16 tps: 99.50 qps: 1590.20 (r/w/o: 1391.20/0.00/199.00) lat (ms,95%): 183.21 err/s: 0.00 reconn/s: 0.00
+[ 80s ] thds: 16 tps: 97.00 qps: 1551.70 (r/w/o: 1357.70/0.00/194.00) lat (ms,95%): 186.54 err/s: 0.00 reconn/s: 0.00
+[ 90s ] thds: 16 tps: 96.20 qps: 1537.70 (r/w/o: 1345.50/0.00/192.20) lat (ms,95%): 183.21 err/s: 0.00 reconn/s: 0.00
+[ 100s ] thds: 16 tps: 100.70 qps: 1616.10 (r/w/o: 1414.50/0.00/201.60) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 110s ] thds: 16 tps: 101.60 qps: 1623.69 (r/w/o: 1420.69/0.00/203.00) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 120s ] thds: 16 tps: 101.30 qps: 1619.31 (r/w/o: 1416.61/0.00/202.70) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 130s ] thds: 16 tps: 101.40 qps: 1620.90 (r/w/o: 1418.10/0.00/202.80) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 140s ] thds: 16 tps: 102.70 qps: 1644.80 (r/w/o: 1439.40/0.00/205.40) lat (ms,95%): 164.45 err/s: 0.00 reconn/s: 0.00
+[ 150s ] thds: 16 tps: 102.50 qps: 1641.00 (r/w/o: 1435.90/0.00/205.10) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 160s ] thds: 16 tps: 99.40 qps: 1592.09 (r/w/o: 1393.39/0.00/198.70) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 170s ] thds: 16 tps: 96.20 qps: 1535.20 (r/w/o: 1343.00/0.00/192.20) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 180s ] thds: 16 tps: 94.10 qps: 1506.99 (r/w/o: 1318.49/0.00/188.50) lat (ms,95%): 240.02 err/s: 0.00 reconn/s: 0.00
+[ 190s ] thds: 16 tps: 97.20 qps: 1557.20 (r/w/o: 1362.90/0.00/194.30) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 200s ] thds: 16 tps: 103.50 qps: 1654.92 (r/w/o: 1447.92/0.00/207.00) lat (ms,95%): 164.45 err/s: 0.00 reconn/s: 0.00
+[ 210s ] thds: 16 tps: 101.40 qps: 1622.59 (r/w/o: 1419.79/0.00/202.80) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 220s ] thds: 16 tps: 100.70 qps: 1611.71 (r/w/o: 1410.21/0.00/201.50) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 230s ] thds: 16 tps: 101.40 qps: 1620.30 (r/w/o: 1417.50/0.00/202.80) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 240s ] thds: 16 tps: 101.60 qps: 1626.80 (r/w/o: 1423.60/0.00/203.20) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 250s ] thds: 16 tps: 101.50 qps: 1619.50 (r/w/o: 1417.00/0.00/202.50) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 260s ] thds: 16 tps: 100.40 qps: 1613.31 (r/w/o: 1412.21/0.00/201.10) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 270s ] thds: 16 tps: 101.50 qps: 1623.40 (r/w/o: 1420.20/0.00/203.20) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 280s ] thds: 16 tps: 97.00 qps: 1549.49 (r/w/o: 1355.59/0.00/193.90) lat (ms,95%): 183.21 err/s: 0.00 reconn/s: 0.00
+[ 290s ] thds: 16 tps: 101.50 qps: 1623.09 (r/w/o: 1420.09/0.00/203.00) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 300s ] thds: 16 tps: 98.20 qps: 1574.01 (r/w/o: 1377.61/0.00/196.40) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 310s ] thds: 16 tps: 103.00 qps: 1646.11 (r/w/o: 1440.20/0.00/205.90) lat (ms,95%): 164.45 err/s: 0.00 reconn/s: 0.00
+[ 320s ] thds: 16 tps: 100.80 qps: 1612.89 (r/w/o: 1411.30/0.00/201.60) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 330s ] thds: 16 tps: 101.30 qps: 1620.40 (r/w/o: 1417.70/0.00/202.70) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 340s ] thds: 16 tps: 99.80 qps: 1593.11 (r/w/o: 1393.71/0.00/199.40) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 350s ] thds: 16 tps: 98.60 qps: 1584.90 (r/w/o: 1387.40/0.00/197.50) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 360s ] thds: 16 tps: 98.50 qps: 1572.79 (r/w/o: 1375.99/0.00/196.80) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 370s ] thds: 16 tps: 98.20 qps: 1573.10 (r/w/o: 1376.60/0.00/196.50) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 380s ] thds: 16 tps: 102.80 qps: 1643.00 (r/w/o: 1437.50/0.00/205.50) lat (ms,95%): 164.45 err/s: 0.00 reconn/s: 0.00
+[ 390s ] thds: 16 tps: 100.20 qps: 1603.90 (r/w/o: 1403.30/0.00/200.60) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 400s ] thds: 16 tps: 99.70 qps: 1594.80 (r/w/o: 1395.40/0.00/199.40) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 410s ] thds: 16 tps: 99.90 qps: 1595.09 (r/w/o: 1395.29/0.00/199.80) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 420s ] thds: 16 tps: 101.70 qps: 1634.11 (r/w/o: 1430.81/0.00/203.30) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 430s ] thds: 16 tps: 98.10 qps: 1559.70 (r/w/o: 1363.60/0.00/196.10) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 440s ] thds: 16 tps: 94.70 qps: 1521.31 (r/w/o: 1331.81/0.00/189.50) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 450s ] thds: 16 tps: 97.00 qps: 1554.69 (r/w/o: 1360.79/0.00/193.90) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 460s ] thds: 16 tps: 97.90 qps: 1560.91 (r/w/o: 1365.10/0.00/195.80) lat (ms,95%): 186.54 err/s: 0.00 reconn/s: 0.00
+[ 470s ] thds: 16 tps: 100.40 qps: 1610.09 (r/w/o: 1409.19/0.00/200.90) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 480s ] thds: 16 tps: 97.50 qps: 1557.50 (r/w/o: 1362.60/0.00/194.90) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 490s ] thds: 16 tps: 100.20 qps: 1605.69 (r/w/o: 1405.19/0.00/200.50) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 500s ] thds: 16 tps: 100.00 qps: 1597.52 (r/w/o: 1397.52/0.00/200.00) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 510s ] thds: 16 tps: 101.80 qps: 1628.49 (r/w/o: 1424.89/0.00/203.60) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 520s ] thds: 16 tps: 95.70 qps: 1530.80 (r/w/o: 1339.40/0.00/191.40) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 530s ] thds: 16 tps: 98.40 qps: 1575.70 (r/w/o: 1378.90/0.00/196.80) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 540s ] thds: 16 tps: 97.80 qps: 1563.21 (r/w/o: 1367.50/0.00/195.70) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 550s ] thds: 16 tps: 102.20 qps: 1639.20 (r/w/o: 1434.80/0.00/204.40) lat (ms,95%): 164.45 err/s: 0.00 reconn/s: 0.00
+[ 560s ] thds: 16 tps: 95.20 qps: 1524.10 (r/w/o: 1333.70/0.00/190.40) lat (ms,95%): 183.21 err/s: 0.00 reconn/s: 0.00
+[ 570s ] thds: 16 tps: 95.90 qps: 1535.60 (r/w/o: 1343.80/0.00/191.80) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 580s ] thds: 16 tps: 94.00 qps: 1499.61 (r/w/o: 1311.81/0.00/187.80) lat (ms,95%): 183.21 err/s: 0.00 reconn/s: 0.00
+[ 590s ] thds: 16 tps: 98.20 qps: 1571.30 (r/w/o: 1375.00/0.00/196.30) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 600s ] thds: 16 tps: 100.10 qps: 1602.49 (r/w/o: 1402.09/0.00/200.40) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+SQL statistics:
+    queries performed:
+        read:                            832580
+        write:                           0
+        other:                           118940
+        total:                           951520
+    transactions:                        59470  (99.09 per sec.)
+    queries:                             951520 (1585.47 per sec.)
+    ignored errors:                      0      (0.00 per sec.)
+    reconnects:                          0      (0.00 per sec.)
+
+Throughput:
+    events/s (eps):                      99.0921
+    time elapsed:                        600.1487s
+    total number of events:              59470
+
+Latency (ms):
+         min:                                  138.66
+         avg:                                  161.44
+         max:                                  492.35
+         95th percentile:                      176.73
+         sum:                              9601029.08
+
+Threads fairness:
+    events (avg/stddev):           3716.8750/40.19
+    execution time (avg/stddev):   600.0643/0.05
+```

--- a/sysbench-reports/rvbox13-gcc-riscv64-linux-gnu-march=rv64gcv_zfh_xtheadba_xtheadcondmov_xtheadmac.md
+++ b/sysbench-reports/rvbox13-gcc-riscv64-linux-gnu-march=rv64gcv_zfh_xtheadba_xtheadcondmov_xtheadmac.md
@@ -1,0 +1,316 @@
+# RVBox13 gcc-riscv64-linux-gnu 编译器（-march=rv64gcv_zfh_xtheadba_xtheadcondmov_xtheadmac）
+## 编译
+```shell
+$ CGO_CFLAGS=-march=rv64gcv_zfh_xtheadba_xtheadcondmov_xtheadmac GOOS=linux GOARCH=riscv64 CC=riscv64-l
+inux-gnu-gcc make server
+```
+
+## 测试
+Point Select
+```shell
+hanbings@sophgo-farm-entrypoint:~$ ./sysbench --config-file=config oltp_point_select --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
+sysbench 1.1.0-de18a03 (using bundled LuaJIT 2.1.0-beta3)
+
+Running the test with following options:
+Number of threads: 16
+Report intermediate results every 10 second(s)
+Initializing random number generator from current time
+
+
+Initializing worker threads...
+
+Threads started!
+
+[ 10s ] thds: 16 tps: 1634.01 qps: 1634.01 (r/w/o: 1634.01/0.00/0.00) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+[ 20s ] thds: 16 tps: 1683.60 qps: 1683.60 (r/w/o: 1683.60/0.00/0.00) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 30s ] thds: 16 tps: 1705.51 qps: 1705.51 (r/w/o: 1705.51/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 40s ] thds: 16 tps: 1658.80 qps: 1658.80 (r/w/o: 1658.80/0.00/0.00) lat (ms,95%): 11.87 err/s: 0.00 reconn/s: 0.00
+[ 50s ] thds: 16 tps: 1736.21 qps: 1736.21 (r/w/o: 1736.21/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 60s ] thds: 16 tps: 1773.00 qps: 1773.00 (r/w/o: 1773.00/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 70s ] thds: 16 tps: 1750.90 qps: 1750.90 (r/w/o: 1750.90/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 80s ] thds: 16 tps: 1698.49 qps: 1698.49 (r/w/o: 1698.49/0.00/0.00) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 90s ] thds: 16 tps: 1663.62 qps: 1663.62 (r/w/o: 1663.62/0.00/0.00) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+[ 100s ] thds: 16 tps: 1679.90 qps: 1679.90 (r/w/o: 1679.90/0.00/0.00) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+[ 110s ] thds: 16 tps: 1675.40 qps: 1675.40 (r/w/o: 1675.40/0.00/0.00) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+[ 120s ] thds: 16 tps: 1721.70 qps: 1721.70 (r/w/o: 1721.70/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 130s ] thds: 16 tps: 1715.80 qps: 1715.80 (r/w/o: 1715.80/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 140s ] thds: 16 tps: 1758.10 qps: 1758.10 (r/w/o: 1758.10/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 150s ] thds: 16 tps: 1746.20 qps: 1746.20 (r/w/o: 1746.20/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 160s ] thds: 16 tps: 1725.40 qps: 1725.40 (r/w/o: 1725.40/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 170s ] thds: 16 tps: 1754.49 qps: 1754.49 (r/w/o: 1754.49/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 180s ] thds: 16 tps: 1768.51 qps: 1768.51 (r/w/o: 1768.51/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 190s ] thds: 16 tps: 1719.80 qps: 1719.80 (r/w/o: 1719.80/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 200s ] thds: 16 tps: 1733.49 qps: 1733.49 (r/w/o: 1733.49/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 210s ] thds: 16 tps: 1711.71 qps: 1711.71 (r/w/o: 1711.71/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 220s ] thds: 16 tps: 1735.00 qps: 1735.00 (r/w/o: 1735.00/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 230s ] thds: 16 tps: 1731.30 qps: 1731.30 (r/w/o: 1731.30/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 240s ] thds: 16 tps: 1745.90 qps: 1745.90 (r/w/o: 1745.90/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 250s ] thds: 16 tps: 1737.31 qps: 1737.31 (r/w/o: 1737.31/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 260s ] thds: 16 tps: 1735.30 qps: 1735.30 (r/w/o: 1735.30/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 270s ] thds: 16 tps: 1729.50 qps: 1729.50 (r/w/o: 1729.50/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 280s ] thds: 16 tps: 1732.50 qps: 1732.50 (r/w/o: 1732.50/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 290s ] thds: 16 tps: 1719.80 qps: 1719.80 (r/w/o: 1719.80/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 300s ] thds: 16 tps: 1743.00 qps: 1743.00 (r/w/o: 1743.00/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 310s ] thds: 16 tps: 1732.41 qps: 1732.41 (r/w/o: 1732.41/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 320s ] thds: 16 tps: 1731.70 qps: 1731.70 (r/w/o: 1731.70/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 330s ] thds: 16 tps: 1763.58 qps: 1763.58 (r/w/o: 1763.58/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 340s ] thds: 16 tps: 1753.82 qps: 1753.82 (r/w/o: 1753.82/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 350s ] thds: 16 tps: 1741.89 qps: 1741.89 (r/w/o: 1741.89/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 360s ] thds: 16 tps: 1758.71 qps: 1758.71 (r/w/o: 1758.71/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 370s ] thds: 16 tps: 1728.39 qps: 1728.39 (r/w/o: 1728.39/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 380s ] thds: 16 tps: 1725.00 qps: 1725.00 (r/w/o: 1725.00/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 390s ] thds: 16 tps: 1731.71 qps: 1731.71 (r/w/o: 1731.71/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 400s ] thds: 16 tps: 1727.70 qps: 1727.70 (r/w/o: 1727.70/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 410s ] thds: 16 tps: 1717.29 qps: 1717.29 (r/w/o: 1717.29/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 420s ] thds: 16 tps: 1724.21 qps: 1724.21 (r/w/o: 1724.21/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 430s ] thds: 16 tps: 1720.30 qps: 1720.30 (r/w/o: 1720.30/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 440s ] thds: 16 tps: 1735.39 qps: 1735.39 (r/w/o: 1735.39/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 450s ] thds: 16 tps: 1736.41 qps: 1736.41 (r/w/o: 1736.41/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 460s ] thds: 16 tps: 1704.90 qps: 1704.90 (r/w/o: 1704.90/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 470s ] thds: 16 tps: 1717.40 qps: 1717.40 (r/w/o: 1717.40/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 480s ] thds: 16 tps: 1722.60 qps: 1722.60 (r/w/o: 1722.60/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 490s ] thds: 16 tps: 1751.30 qps: 1751.30 (r/w/o: 1751.30/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 500s ] thds: 16 tps: 1732.68 qps: 1732.68 (r/w/o: 1732.68/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 510s ] thds: 16 tps: 1736.31 qps: 1736.31 (r/w/o: 1736.31/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 520s ] thds: 16 tps: 1749.70 qps: 1749.70 (r/w/o: 1749.70/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 530s ] thds: 16 tps: 1727.90 qps: 1727.90 (r/w/o: 1727.90/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 540s ] thds: 16 tps: 1719.70 qps: 1719.70 (r/w/o: 1719.70/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 550s ] thds: 16 tps: 1721.91 qps: 1721.91 (r/w/o: 1721.91/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 560s ] thds: 16 tps: 1733.30 qps: 1733.30 (r/w/o: 1733.30/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 570s ] thds: 16 tps: 1745.39 qps: 1745.39 (r/w/o: 1745.39/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 580s ] thds: 16 tps: 1834.20 qps: 1834.20 (r/w/o: 1834.20/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 590s ] thds: 16 tps: 1776.00 qps: 1776.00 (r/w/o: 1776.00/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 600s ] thds: 16 tps: 1737.40 qps: 1737.40 (r/w/o: 1737.40/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+SQL statistics:
+    queries performed:
+        read:                            1037653
+        write:                           0
+        other:                           0
+        total:                           1037653
+    transactions:                        1037653 (1729.39 per sec.)
+    queries:                             1037653 (1729.39 per sec.)
+    ignored errors:                      0      (0.00 per sec.)
+    reconnects:                          0      (0.00 per sec.)
+
+Throughput:
+    events/s (eps):                      1729.3882
+    time elapsed:                        600.0116s
+    total number of events:              1037653
+
+Latency (ms):
+         min:                                    5.30
+         avg:                                    9.25
+         max:                                   60.33
+         95th percentile:                       10.84
+         sum:                              9599530.92
+
+Threads fairness:
+    events (avg/stddev):           64853.3125/5644.24
+    execution time (avg/stddev):   599.9707/0.02
+```
+
+Update Index
+```shell
+hanbings@sophgo-farm-entrypoint:~$ ./sysbench --config-file=config oltp_update_index --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
+sysbench 1.1.0-de18a03 (using bundled LuaJIT 2.1.0-beta3)
+
+Running the test with following options:
+Number of threads: 16
+Report intermediate results every 10 second(s)
+Initializing random number generator from current time
+
+
+Initializing worker threads...
+
+Threads started!
+
+[ 10s ] thds: 16 tps: 1489.04 qps: 1489.04 (r/w/o: 0.00/1466.14/22.90) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 20s ] thds: 16 tps: 1497.51 qps: 1497.51 (r/w/o: 0.00/1477.91/19.60) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 30s ] thds: 16 tps: 1513.39 qps: 1513.39 (r/w/o: 0.00/1491.59/21.80) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 40s ] thds: 16 tps: 1530.19 qps: 1530.19 (r/w/o: 0.00/1503.29/26.90) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 50s ] thds: 16 tps: 1530.01 qps: 1530.01 (r/w/o: 0.00/1507.81/22.20) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 60s ] thds: 16 tps: 1511.00 qps: 1511.00 (r/w/o: 0.00/1488.40/22.60) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 70s ] thds: 16 tps: 1531.31 qps: 1531.31 (r/w/o: 0.00/1509.31/22.00) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 80s ] thds: 16 tps: 1523.30 qps: 1523.30 (r/w/o: 0.00/1504.00/19.30) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 90s ] thds: 16 tps: 1513.69 qps: 1513.69 (r/w/o: 0.00/1488.79/24.90) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 100s ] thds: 16 tps: 1541.61 qps: 1541.61 (r/w/o: 0.00/1517.31/24.30) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 110s ] thds: 16 tps: 1521.10 qps: 1521.10 (r/w/o: 0.00/1498.80/22.30) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 120s ] thds: 16 tps: 1474.60 qps: 1474.60 (r/w/o: 0.00/1452.70/21.90) lat (ms,95%): 13.22 err/s: 0.00 reconn/s: 0.00
+[ 130s ] thds: 16 tps: 1491.81 qps: 1491.81 (r/w/o: 0.00/1469.11/22.70) lat (ms,95%): 13.22 err/s: 0.00 reconn/s: 0.00
+[ 140s ] thds: 16 tps: 1580.79 qps: 1580.79 (r/w/o: 0.00/1557.39/23.40) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 150s ] thds: 16 tps: 1545.20 qps: 1545.20 (r/w/o: 0.00/1523.40/21.80) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 160s ] thds: 16 tps: 1553.00 qps: 1553.00 (r/w/o: 0.00/1530.70/22.30) lat (ms,95%): 11.45 err/s: 0.00 reconn/s: 0.00
+[ 170s ] thds: 16 tps: 1561.01 qps: 1561.01 (r/w/o: 0.00/1541.21/19.80) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 180s ] thds: 16 tps: 1500.70 qps: 1500.70 (r/w/o: 0.00/1479.30/21.40) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 190s ] thds: 16 tps: 1531.30 qps: 1531.30 (r/w/o: 0.00/1512.90/18.40) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 200s ] thds: 16 tps: 1548.90 qps: 1548.90 (r/w/o: 0.00/1527.20/21.70) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 210s ] thds: 16 tps: 1589.31 qps: 1589.31 (r/w/o: 0.00/1569.51/19.80) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 220s ] thds: 16 tps: 1583.79 qps: 1583.79 (r/w/o: 0.00/1558.09/25.70) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 230s ] thds: 16 tps: 1543.90 qps: 1543.90 (r/w/o: 0.00/1523.00/20.90) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 240s ] thds: 16 tps: 1513.09 qps: 1513.09 (r/w/o: 0.00/1492.09/21.00) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 250s ] thds: 16 tps: 1535.11 qps: 1535.11 (r/w/o: 0.00/1514.71/20.40) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 260s ] thds: 16 tps: 1528.40 qps: 1528.40 (r/w/o: 0.00/1507.50/20.90) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 270s ] thds: 16 tps: 1546.80 qps: 1546.80 (r/w/o: 0.00/1524.30/22.50) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 280s ] thds: 16 tps: 1525.09 qps: 1525.09 (r/w/o: 0.00/1505.09/20.00) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 290s ] thds: 16 tps: 1399.80 qps: 1399.80 (r/w/o: 0.00/1380.80/19.00) lat (ms,95%): 13.22 err/s: 0.00 reconn/s: 0.00
+[ 300s ] thds: 16 tps: 1478.70 qps: 1478.70 (r/w/o: 0.00/1458.50/20.20) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 310s ] thds: 16 tps: 1541.81 qps: 1541.81 (r/w/o: 0.00/1521.01/20.80) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 320s ] thds: 16 tps: 1514.40 qps: 1514.40 (r/w/o: 0.00/1493.00/21.40) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 330s ] thds: 16 tps: 1522.68 qps: 1522.68 (r/w/o: 0.00/1501.08/21.60) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 340s ] thds: 16 tps: 1521.41 qps: 1521.41 (r/w/o: 0.00/1496.51/24.90) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 350s ] thds: 16 tps: 1531.59 qps: 1531.59 (r/w/o: 0.00/1507.59/24.00) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 360s ] thds: 16 tps: 1485.50 qps: 1485.50 (r/w/o: 0.00/1462.50/23.00) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 370s ] thds: 16 tps: 1588.20 qps: 1588.20 (r/w/o: 0.00/1565.00/23.20) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 380s ] thds: 16 tps: 1596.00 qps: 1596.00 (r/w/o: 0.00/1573.70/22.30) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 390s ] thds: 16 tps: 1563.40 qps: 1563.40 (r/w/o: 0.00/1539.70/23.70) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 400s ] thds: 16 tps: 1545.10 qps: 1545.10 (r/w/o: 0.00/1524.80/20.30) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 410s ] thds: 16 tps: 1548.60 qps: 1548.60 (r/w/o: 0.00/1526.90/21.70) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 420s ] thds: 16 tps: 1483.10 qps: 1483.10 (r/w/o: 0.00/1463.40/19.70) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 430s ] thds: 16 tps: 1528.50 qps: 1528.50 (r/w/o: 0.00/1506.10/22.40) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 440s ] thds: 16 tps: 1535.10 qps: 1535.10 (r/w/o: 0.00/1511.70/23.40) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 450s ] thds: 16 tps: 1514.79 qps: 1514.79 (r/w/o: 0.00/1494.19/20.60) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 460s ] thds: 16 tps: 1530.91 qps: 1530.91 (r/w/o: 0.00/1511.61/19.30) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 470s ] thds: 16 tps: 1538.20 qps: 1538.20 (r/w/o: 0.00/1514.90/23.30) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 480s ] thds: 16 tps: 1523.79 qps: 1523.79 (r/w/o: 0.00/1502.99/20.80) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 490s ] thds: 16 tps: 1554.11 qps: 1554.11 (r/w/o: 0.00/1532.81/21.30) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 500s ] thds: 16 tps: 1482.30 qps: 1482.30 (r/w/o: 0.00/1462.40/19.90) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 510s ] thds: 16 tps: 1541.10 qps: 1541.10 (r/w/o: 0.00/1519.80/21.30) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 520s ] thds: 16 tps: 1570.70 qps: 1570.70 (r/w/o: 0.00/1549.40/21.30) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+[ 530s ] thds: 16 tps: 1543.20 qps: 1543.20 (r/w/o: 0.00/1524.10/19.10) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 540s ] thds: 16 tps: 1481.49 qps: 1481.49 (r/w/o: 0.00/1460.89/20.60) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 550s ] thds: 16 tps: 1549.00 qps: 1549.00 (r/w/o: 0.00/1526.40/22.60) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 560s ] thds: 16 tps: 1538.61 qps: 1538.61 (r/w/o: 0.00/1517.41/21.20) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 570s ] thds: 16 tps: 1580.00 qps: 1580.00 (r/w/o: 0.00/1557.30/22.70) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 580s ] thds: 16 tps: 1572.60 qps: 1572.60 (r/w/o: 0.00/1548.50/24.10) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 590s ] thds: 16 tps: 1567.11 qps: 1567.11 (r/w/o: 0.00/1544.21/22.90) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 600s ] thds: 16 tps: 1523.60 qps: 1523.60 (r/w/o: 0.00/1502.10/21.50) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+SQL statistics:
+    queries performed:
+        read:                            0
+        write:                           905446
+        other:                           13076
+        total:                           918522
+    transactions:                        918522 (1530.84 per sec.)
+    queries:                             918522 (1530.84 per sec.)
+    ignored errors:                      0      (0.00 per sec.)
+    reconnects:                          0      (0.00 per sec.)
+
+Throughput:
+    events/s (eps):                      1530.8406
+    time elapsed:                        600.0115s
+    total number of events:              918522
+
+Latency (ms):
+         min:                                    5.14
+         avg:                                   10.45
+         max:                                  152.03
+         95th percentile:                       12.52
+         sum:                              9599587.03
+
+Threads fairness:
+    events (avg/stddev):           57407.6250/373.74
+    execution time (avg/stddev):   599.9742/0.01
+```
+
+Read Only
+```shell
+hanbings@sophgo-farm-entrypoint:~$ ./sysbench --config-file=config oltp_read_only --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
+sysbench 1.1.0-de18a03 (using bundled LuaJIT 2.1.0-beta3)
+
+Running the test with following options:
+Number of threads: 16
+Report intermediate results every 10 second(s)
+Initializing random number generator from current time
+
+
+Initializing worker threads...
+
+Threads started!
+
+[ 10s ] thds: 16 tps: 90.58 qps: 1464.30 (r/w/o: 1281.54/0.00/182.76) lat (ms,95%): 204.11 err/s: 0.00 reconn/s: 0.00
+[ 20s ] thds: 16 tps: 83.80 qps: 1340.44 (r/w/o: 1172.84/0.00/167.61) lat (ms,95%): 253.35 err/s: 0.00 reconn/s: 0.00
+[ 30s ] thds: 16 tps: 75.80 qps: 1214.69 (r/w/o: 1063.19/0.00/151.50) lat (ms,95%): 320.17 err/s: 0.00 reconn/s: 0.00
+[ 40s ] thds: 16 tps: 86.90 qps: 1388.11 (r/w/o: 1214.21/0.00/173.90) lat (ms,95%): 227.40 err/s: 0.00 reconn/s: 0.00
+[ 50s ] thds: 16 tps: 93.40 qps: 1493.90 (r/w/o: 1307.10/0.00/186.80) lat (ms,95%): 219.36 err/s: 0.00 reconn/s: 0.00
+[ 60s ] thds: 16 tps: 99.50 qps: 1590.87 (r/w/o: 1392.08/0.00/198.80) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 70s ] thds: 16 tps: 98.80 qps: 1579.53 (r/w/o: 1381.93/0.00/197.60) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 80s ] thds: 16 tps: 96.60 qps: 1546.60 (r/w/o: 1353.40/0.00/193.20) lat (ms,95%): 211.60 err/s: 0.00 reconn/s: 0.00
+[ 90s ] thds: 16 tps: 97.10 qps: 1557.09 (r/w/o: 1362.69/0.00/194.40) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 100s ] thds: 16 tps: 97.30 qps: 1553.11 (r/w/o: 1358.61/0.00/194.50) lat (ms,95%): 183.21 err/s: 0.00 reconn/s: 0.00
+[ 110s ] thds: 16 tps: 100.10 qps: 1602.20 (r/w/o: 1402.00/0.00/200.20) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 120s ] thds: 16 tps: 103.30 qps: 1654.50 (r/w/o: 1447.80/0.00/206.70) lat (ms,95%): 164.45 err/s: 0.00 reconn/s: 0.00
+[ 130s ] thds: 16 tps: 100.20 qps: 1603.70 (r/w/o: 1403.30/0.00/200.40) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 140s ] thds: 16 tps: 98.30 qps: 1572.80 (r/w/o: 1376.20/0.00/196.60) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 150s ] thds: 16 tps: 102.60 qps: 1637.80 (r/w/o: 1432.70/0.00/205.10) lat (ms,95%): 164.45 err/s: 0.00 reconn/s: 0.00
+[ 160s ] thds: 16 tps: 99.10 qps: 1587.20 (r/w/o: 1389.00/0.00/198.20) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 170s ] thds: 16 tps: 98.20 qps: 1573.99 (r/w/o: 1377.50/0.00/196.50) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 180s ] thds: 16 tps: 101.40 qps: 1620.61 (r/w/o: 1417.81/0.00/202.80) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 190s ] thds: 16 tps: 101.10 qps: 1619.00 (r/w/o: 1416.90/0.00/202.10) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 200s ] thds: 16 tps: 101.00 qps: 1611.60 (r/w/o: 1409.60/0.00/202.00) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 210s ] thds: 16 tps: 101.30 qps: 1623.60 (r/w/o: 1420.90/0.00/202.70) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 220s ] thds: 16 tps: 95.90 qps: 1534.18 (r/w/o: 1342.39/0.00/191.80) lat (ms,95%): 211.60 err/s: 0.00 reconn/s: 0.00
+[ 230s ] thds: 16 tps: 95.90 qps: 1535.20 (r/w/o: 1343.60/0.00/191.60) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 240s ] thds: 16 tps: 101.10 qps: 1617.52 (r/w/o: 1415.22/0.00/202.30) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 250s ] thds: 16 tps: 99.10 qps: 1582.79 (r/w/o: 1384.49/0.00/198.30) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 260s ] thds: 16 tps: 101.80 qps: 1629.80 (r/w/o: 1426.20/0.00/203.60) lat (ms,95%): 164.45 err/s: 0.00 reconn/s: 0.00
+[ 270s ] thds: 16 tps: 102.20 qps: 1638.10 (r/w/o: 1433.70/0.00/204.40) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 280s ] thds: 16 tps: 100.70 qps: 1609.11 (r/w/o: 1407.71/0.00/201.40) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 290s ] thds: 16 tps: 101.70 qps: 1626.80 (r/w/o: 1423.70/0.00/203.10) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 300s ] thds: 16 tps: 98.80 qps: 1584.28 (r/w/o: 1386.39/0.00/197.90) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 310s ] thds: 16 tps: 99.70 qps: 1593.02 (r/w/o: 1393.71/0.00/199.30) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 320s ] thds: 16 tps: 101.90 qps: 1629.30 (r/w/o: 1425.50/0.00/203.80) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 330s ] thds: 16 tps: 99.30 qps: 1588.39 (r/w/o: 1389.89/0.00/198.50) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 340s ] thds: 16 tps: 96.70 qps: 1546.10 (r/w/o: 1352.80/0.00/193.30) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 350s ] thds: 16 tps: 101.50 qps: 1625.51 (r/w/o: 1422.20/0.00/203.30) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 360s ] thds: 16 tps: 100.20 qps: 1605.60 (r/w/o: 1405.20/0.00/200.40) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 370s ] thds: 16 tps: 102.50 qps: 1637.30 (r/w/o: 1432.30/0.00/205.00) lat (ms,95%): 164.45 err/s: 0.00 reconn/s: 0.00
+[ 380s ] thds: 16 tps: 99.40 qps: 1589.10 (r/w/o: 1390.40/0.00/198.70) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 390s ] thds: 16 tps: 101.60 qps: 1626.30 (r/w/o: 1423.00/0.00/203.30) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 400s ] thds: 16 tps: 95.40 qps: 1528.30 (r/w/o: 1337.70/0.00/190.60) lat (ms,95%): 193.38 err/s: 0.00 reconn/s: 0.00
+[ 410s ] thds: 16 tps: 94.70 qps: 1514.90 (r/w/o: 1325.40/0.00/189.50) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 420s ] thds: 16 tps: 94.60 qps: 1510.60 (r/w/o: 1321.40/0.00/189.20) lat (ms,95%): 211.60 err/s: 0.00 reconn/s: 0.00
+[ 430s ] thds: 16 tps: 93.90 qps: 1504.70 (r/w/o: 1316.80/0.00/187.90) lat (ms,95%): 219.36 err/s: 0.00 reconn/s: 0.00
+[ 440s ] thds: 16 tps: 95.40 qps: 1527.20 (r/w/o: 1336.70/0.00/190.50) lat (ms,95%): 186.54 err/s: 0.00 reconn/s: 0.00
+[ 450s ] thds: 16 tps: 98.20 qps: 1568.30 (r/w/o: 1371.60/0.00/196.70) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 460s ] thds: 16 tps: 96.60 qps: 1545.71 (r/w/o: 1352.51/0.00/193.20) lat (ms,95%): 183.21 err/s: 0.00 reconn/s: 0.00
+[ 470s ] thds: 16 tps: 93.90 qps: 1503.59 (r/w/o: 1315.89/0.00/187.70) lat (ms,95%): 227.40 err/s: 0.00 reconn/s: 0.00
+[ 480s ] thds: 16 tps: 98.80 qps: 1582.81 (r/w/o: 1385.41/0.00/197.40) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 490s ] thds: 16 tps: 95.70 qps: 1532.90 (r/w/o: 1341.20/0.00/191.70) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 500s ] thds: 16 tps: 93.50 qps: 1494.41 (r/w/o: 1307.41/0.00/187.00) lat (ms,95%): 219.36 err/s: 0.00 reconn/s: 0.00
+[ 510s ] thds: 16 tps: 86.60 qps: 1382.60 (r/w/o: 1209.50/0.00/173.10) lat (ms,95%): 257.95 err/s: 0.00 reconn/s: 0.00
+[ 520s ] thds: 16 tps: 91.70 qps: 1470.10 (r/w/o: 1286.70/0.00/183.40) lat (ms,95%): 244.38 err/s: 0.00 reconn/s: 0.00
+[ 530s ] thds: 16 tps: 85.50 qps: 1364.50 (r/w/o: 1193.50/0.00/171.00) lat (ms,95%): 257.95 err/s: 0.00 reconn/s: 0.00
+[ 540s ] thds: 16 tps: 84.40 qps: 1354.29 (r/w/o: 1185.69/0.00/168.60) lat (ms,95%): 257.95 err/s: 0.00 reconn/s: 0.00
+[ 550s ] thds: 16 tps: 93.70 qps: 1501.11 (r/w/o: 1313.51/0.00/187.60) lat (ms,95%): 215.44 err/s: 0.00 reconn/s: 0.00
+[ 560s ] thds: 16 tps: 90.80 qps: 1447.90 (r/w/o: 1266.40/0.00/181.50) lat (ms,95%): 248.83 err/s: 0.00 reconn/s: 0.00
+[ 570s ] thds: 16 tps: 95.40 qps: 1528.20 (r/w/o: 1337.30/0.00/190.90) lat (ms,95%): 200.47 err/s: 0.00 reconn/s: 0.00
+[ 580s ] thds: 16 tps: 88.80 qps: 1423.80 (r/w/o: 1246.10/0.00/177.70) lat (ms,95%): 231.53 err/s: 0.00 reconn/s: 0.00
+[ 590s ] thds: 16 tps: 95.60 qps: 1527.90 (r/w/o: 1336.90/0.00/191.00) lat (ms,95%): 227.40 err/s: 0.00 reconn/s: 0.00
+[ 600s ] thds: 16 tps: 95.90 qps: 1532.00 (r/w/o: 1340.20/0.00/191.80) lat (ms,95%): 231.53 err/s: 0.00 reconn/s: 0.00
+SQL statistics:
+    queries performed:
+        read:                            810194
+        write:                           0
+        other:                           115742
+        total:                           925936
+    transactions:                        57871  (96.42 per sec.)
+    queries:                             925936 (1542.77 per sec.)
+    ignored errors:                      0      (0.00 per sec.)
+    reconnects:                          0      (0.00 per sec.)
+
+Throughput:
+    events/s (eps):                      96.4231
+    time elapsed:                        600.1775s
+    total number of events:              57871
+
+Latency (ms):
+         min:                                  140.44
+         avg:                                  165.91
+         max:                                  490.95
+         95th percentile:                      200.47
+         sum:                              9601272.86
+
+Threads fairness:
+    events (avg/stddev):           3616.9375/41.47
+    execution time (avg/stddev):   600.0796/0.07
+```

--- a/sysbench-reports/rvbox13-gcc-riscv64-linux-gnu-mtune=thead-c906.md
+++ b/sysbench-reports/rvbox13-gcc-riscv64-linux-gnu-mtune=thead-c906.md
@@ -1,0 +1,315 @@
+# RVBox13 gcc-riscv64-linux-gnu 编译器（-mtune=thead-c906）
+## 编译
+```shell
+$ CGO_CFLAGS=-mtune=thead-c906 GOOS=linux GOARCH=riscv64 CC=riscv64-linux-gnu-gcc make server
+```
+
+## 测试
+Point Select
+```shell
+hanbings@sophgo-farm-entrypoint:~$ ./sysbench --config-file=config oltp_point_select --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
+sysbench 1.1.0-de18a03 (using bundled LuaJIT 2.1.0-beta3)
+
+Running the test with following options:
+Number of threads: 16
+Report intermediate results every 10 second(s)
+Initializing random number generator from current time
+
+
+Initializing worker threads...
+
+Threads started!
+
+[ 10s ] thds: 16 tps: 1651.11 qps: 1651.11 (r/w/o: 1651.11/0.00/0.00) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 20s ] thds: 16 tps: 1632.10 qps: 1632.10 (r/w/o: 1632.10/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 30s ] thds: 16 tps: 1459.70 qps: 1459.70 (r/w/o: 1459.70/0.00/0.00) lat (ms,95%): 17.63 err/s: 0.00 reconn/s: 0.00
+[ 40s ] thds: 16 tps: 1516.39 qps: 1516.39 (r/w/o: 1516.39/0.00/0.00) lat (ms,95%): 17.32 err/s: 0.00 reconn/s: 0.00
+[ 50s ] thds: 16 tps: 1693.61 qps: 1693.61 (r/w/o: 1693.61/0.00/0.00) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 60s ] thds: 16 tps: 1689.80 qps: 1689.80 (r/w/o: 1689.80/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 70s ] thds: 16 tps: 1725.10 qps: 1725.10 (r/w/o: 1725.10/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 80s ] thds: 16 tps: 1755.70 qps: 1755.70 (r/w/o: 1755.70/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 90s ] thds: 16 tps: 1740.10 qps: 1740.10 (r/w/o: 1740.10/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 100s ] thds: 16 tps: 1796.89 qps: 1796.89 (r/w/o: 1796.89/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 110s ] thds: 16 tps: 1690.91 qps: 1690.91 (r/w/o: 1690.91/0.00/0.00) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 120s ] thds: 16 tps: 1721.20 qps: 1721.20 (r/w/o: 1721.20/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 130s ] thds: 16 tps: 1504.80 qps: 1504.80 (r/w/o: 1504.80/0.00/0.00) lat (ms,95%): 17.01 err/s: 0.00 reconn/s: 0.00
+[ 140s ] thds: 16 tps: 1684.89 qps: 1684.89 (r/w/o: 1684.89/0.00/0.00) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 150s ] thds: 16 tps: 1625.61 qps: 1625.61 (r/w/o: 1625.61/0.00/0.00) lat (ms,95%): 13.70 err/s: 0.00 reconn/s: 0.00
+[ 160s ] thds: 16 tps: 1715.20 qps: 1715.20 (r/w/o: 1715.20/0.00/0.00) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 170s ] thds: 16 tps: 1621.00 qps: 1621.00 (r/w/o: 1621.00/0.00/0.00) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 180s ] thds: 16 tps: 1684.11 qps: 1684.11 (r/w/o: 1684.11/0.00/0.00) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 190s ] thds: 16 tps: 1676.60 qps: 1676.60 (r/w/o: 1676.60/0.00/0.00) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+[ 200s ] thds: 16 tps: 1711.40 qps: 1711.40 (r/w/o: 1711.40/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 210s ] thds: 16 tps: 1698.81 qps: 1698.81 (r/w/o: 1698.81/0.00/0.00) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 220s ] thds: 16 tps: 1706.70 qps: 1706.70 (r/w/o: 1706.70/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 230s ] thds: 16 tps: 1726.00 qps: 1726.00 (r/w/o: 1726.00/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 240s ] thds: 16 tps: 1774.90 qps: 1774.90 (r/w/o: 1774.90/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 250s ] thds: 16 tps: 1659.80 qps: 1659.80 (r/w/o: 1659.80/0.00/0.00) lat (ms,95%): 13.22 err/s: 0.00 reconn/s: 0.00
+[ 260s ] thds: 16 tps: 1706.11 qps: 1706.11 (r/w/o: 1706.11/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 270s ] thds: 16 tps: 1743.79 qps: 1743.79 (r/w/o: 1743.79/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 280s ] thds: 16 tps: 1728.90 qps: 1728.90 (r/w/o: 1728.90/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 290s ] thds: 16 tps: 1713.91 qps: 1713.91 (r/w/o: 1713.91/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 300s ] thds: 16 tps: 1691.60 qps: 1691.60 (r/w/o: 1691.60/0.00/0.00) lat (ms,95%): 11.45 err/s: 0.00 reconn/s: 0.00
+[ 310s ] thds: 16 tps: 1727.60 qps: 1727.60 (r/w/o: 1727.60/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 320s ] thds: 16 tps: 1692.29 qps: 1692.29 (r/w/o: 1692.29/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 330s ] thds: 16 tps: 1703.10 qps: 1703.10 (r/w/o: 1703.10/0.00/0.00) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 340s ] thds: 16 tps: 1698.81 qps: 1698.81 (r/w/o: 1698.81/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 350s ] thds: 16 tps: 1678.19 qps: 1678.19 (r/w/o: 1678.19/0.00/0.00) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 360s ] thds: 16 tps: 1696.10 qps: 1696.10 (r/w/o: 1696.10/0.00/0.00) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+[ 370s ] thds: 16 tps: 1709.41 qps: 1709.41 (r/w/o: 1709.41/0.00/0.00) lat (ms,95%): 11.45 err/s: 0.00 reconn/s: 0.00
+[ 380s ] thds: 16 tps: 1723.79 qps: 1723.79 (r/w/o: 1723.79/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 390s ] thds: 16 tps: 1690.10 qps: 1690.10 (r/w/o: 1690.10/0.00/0.00) lat (ms,95%): 11.45 err/s: 0.00 reconn/s: 0.00
+[ 400s ] thds: 16 tps: 1656.41 qps: 1656.41 (r/w/o: 1656.41/0.00/0.00) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 410s ] thds: 16 tps: 1617.89 qps: 1617.89 (r/w/o: 1617.89/0.00/0.00) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 420s ] thds: 16 tps: 1703.71 qps: 1703.71 (r/w/o: 1703.71/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 430s ] thds: 16 tps: 1703.20 qps: 1703.20 (r/w/o: 1703.20/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 440s ] thds: 16 tps: 1662.50 qps: 1662.50 (r/w/o: 1662.50/0.00/0.00) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 450s ] thds: 16 tps: 1739.90 qps: 1739.90 (r/w/o: 1739.90/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 460s ] thds: 16 tps: 1709.09 qps: 1709.09 (r/w/o: 1709.09/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 470s ] thds: 16 tps: 1703.71 qps: 1703.71 (r/w/o: 1703.71/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 480s ] thds: 16 tps: 1620.29 qps: 1620.29 (r/w/o: 1620.29/0.00/0.00) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+[ 490s ] thds: 16 tps: 1750.61 qps: 1750.61 (r/w/o: 1750.61/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 500s ] thds: 16 tps: 1767.79 qps: 1767.79 (r/w/o: 1767.79/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 510s ] thds: 16 tps: 1718.10 qps: 1718.10 (r/w/o: 1718.10/0.00/0.00) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 520s ] thds: 16 tps: 1714.51 qps: 1714.51 (r/w/o: 1714.51/0.00/0.00) lat (ms,95%): 11.45 err/s: 0.00 reconn/s: 0.00
+[ 530s ] thds: 16 tps: 1723.50 qps: 1723.50 (r/w/o: 1723.50/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 540s ] thds: 16 tps: 1638.90 qps: 1638.90 (r/w/o: 1638.90/0.00/0.00) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 550s ] thds: 16 tps: 1722.09 qps: 1722.09 (r/w/o: 1722.09/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 560s ] thds: 16 tps: 1726.90 qps: 1726.90 (r/w/o: 1726.90/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 570s ] thds: 16 tps: 1694.71 qps: 1694.71 (r/w/o: 1694.71/0.00/0.00) lat (ms,95%): 11.45 err/s: 0.00 reconn/s: 0.00
+[ 580s ] thds: 16 tps: 1710.00 qps: 1710.00 (r/w/o: 1710.00/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 590s ] thds: 16 tps: 1743.29 qps: 1743.29 (r/w/o: 1743.29/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 600s ] thds: 16 tps: 1762.20 qps: 1762.20 (r/w/o: 1762.20/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+SQL statistics:
+    queries performed:
+        read:                            1015573
+        write:                           0
+        other:                           0
+        total:                           1015573
+    transactions:                        1015573 (1692.59 per sec.)
+    queries:                             1015573 (1692.59 per sec.)
+    ignored errors:                      0      (0.00 per sec.)
+    reconnects:                          0      (0.00 per sec.)
+
+Throughput:
+    events/s (eps):                      1692.5950
+    time elapsed:                        600.0095s
+    total number of events:              1015573
+
+Latency (ms):
+         min:                                    5.25
+         avg:                                    9.45
+         max:                                  154.02
+         95th percentile:                       11.45
+         sum:                              9599517.95
+
+Threads fairness:
+    events (avg/stddev):           63473.3125/5157.91
+    execution time (avg/stddev):   599.9699/0.02
+```
+
+Update Index
+```shell
+hanbings@sophgo-farm-entrypoint:~$ ./sysbench --config-file=config oltp_update_index --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
+sysbench 1.1.0-de18a03 (using bundled LuaJIT 2.1.0-beta3)
+
+Running the test with following options:
+Number of threads: 16
+Report intermediate results every 10 second(s)
+Initializing random number generator from current time
+
+
+Initializing worker threads...
+
+Threads started!
+
+[ 10s ] thds: 16 tps: 1517.83 qps: 1517.83 (r/w/o: 0.00/1496.23/21.60) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 20s ] thds: 16 tps: 1585.50 qps: 1585.50 (r/w/o: 0.00/1563.00/22.50) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 30s ] thds: 16 tps: 1481.60 qps: 1481.60 (r/w/o: 0.00/1457.20/24.40) lat (ms,95%): 13.22 err/s: 0.00 reconn/s: 0.00
+[ 40s ] thds: 16 tps: 1536.81 qps: 1536.81 (r/w/o: 0.00/1515.21/21.60) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 50s ] thds: 16 tps: 1551.70 qps: 1551.70 (r/w/o: 0.00/1528.80/22.90) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+[ 60s ] thds: 16 tps: 1517.50 qps: 1517.50 (r/w/o: 0.00/1495.70/21.80) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 70s ] thds: 16 tps: 1505.90 qps: 1505.90 (r/w/o: 0.00/1484.70/21.20) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 80s ] thds: 16 tps: 1511.90 qps: 1511.90 (r/w/o: 0.00/1490.90/21.00) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 90s ] thds: 16 tps: 1518.70 qps: 1518.70 (r/w/o: 0.00/1496.60/22.10) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 100s ] thds: 16 tps: 1543.81 qps: 1543.81 (r/w/o: 0.00/1521.51/22.30) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 110s ] thds: 16 tps: 1515.60 qps: 1515.60 (r/w/o: 0.00/1496.20/19.40) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 120s ] thds: 16 tps: 1564.79 qps: 1564.79 (r/w/o: 0.00/1540.19/24.60) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 130s ] thds: 16 tps: 1572.00 qps: 1572.00 (r/w/o: 0.00/1550.50/21.50) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 140s ] thds: 16 tps: 1553.81 qps: 1553.81 (r/w/o: 0.00/1533.21/20.60) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 150s ] thds: 16 tps: 1505.80 qps: 1505.80 (r/w/o: 0.00/1483.50/22.30) lat (ms,95%): 11.45 err/s: 0.00 reconn/s: 0.00
+[ 160s ] thds: 16 tps: 1552.50 qps: 1552.50 (r/w/o: 0.00/1531.30/21.20) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 170s ] thds: 16 tps: 1522.31 qps: 1522.31 (r/w/o: 0.00/1501.91/20.40) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 180s ] thds: 16 tps: 1579.79 qps: 1579.79 (r/w/o: 0.00/1559.39/20.40) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 190s ] thds: 16 tps: 1519.79 qps: 1519.79 (r/w/o: 0.00/1499.69/20.10) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 200s ] thds: 16 tps: 1518.81 qps: 1518.81 (r/w/o: 0.00/1496.71/22.10) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 210s ] thds: 16 tps: 1524.00 qps: 1524.00 (r/w/o: 0.00/1506.10/17.90) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 220s ] thds: 16 tps: 1545.29 qps: 1545.29 (r/w/o: 0.00/1523.39/21.90) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 230s ] thds: 16 tps: 1499.40 qps: 1499.40 (r/w/o: 0.00/1480.40/19.00) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 240s ] thds: 16 tps: 1542.39 qps: 1542.39 (r/w/o: 0.00/1520.89/21.50) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 250s ] thds: 16 tps: 1542.11 qps: 1542.11 (r/w/o: 0.00/1520.31/21.80) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 260s ] thds: 16 tps: 1559.70 qps: 1559.70 (r/w/o: 0.00/1536.00/23.70) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+[ 270s ] thds: 16 tps: 1546.10 qps: 1546.10 (r/w/o: 0.00/1525.40/20.70) lat (ms,95%): 11.45 err/s: 0.00 reconn/s: 0.00
+[ 280s ] thds: 16 tps: 1544.30 qps: 1544.30 (r/w/o: 0.00/1521.70/22.60) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 290s ] thds: 16 tps: 1502.91 qps: 1502.91 (r/w/o: 0.00/1481.91/21.00) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 300s ] thds: 16 tps: 1547.00 qps: 1547.00 (r/w/o: 0.00/1527.20/19.80) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 310s ] thds: 16 tps: 1542.30 qps: 1542.30 (r/w/o: 0.00/1519.20/23.10) lat (ms,95%): 11.45 err/s: 0.00 reconn/s: 0.00
+[ 320s ] thds: 16 tps: 1569.50 qps: 1569.50 (r/w/o: 0.00/1546.10/23.40) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 330s ] thds: 16 tps: 1570.31 qps: 1570.31 (r/w/o: 0.00/1547.01/23.30) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 340s ] thds: 16 tps: 1582.40 qps: 1582.40 (r/w/o: 0.00/1559.40/23.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 350s ] thds: 16 tps: 1560.30 qps: 1560.30 (r/w/o: 0.00/1537.90/22.40) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 360s ] thds: 16 tps: 1584.70 qps: 1584.70 (r/w/o: 0.00/1560.90/23.80) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 370s ] thds: 16 tps: 1582.30 qps: 1582.30 (r/w/o: 0.00/1559.90/22.40) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 380s ] thds: 16 tps: 1565.90 qps: 1565.90 (r/w/o: 0.00/1542.80/23.10) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 390s ] thds: 16 tps: 1551.81 qps: 1551.81 (r/w/o: 0.00/1526.71/25.10) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 400s ] thds: 16 tps: 1569.20 qps: 1569.20 (r/w/o: 0.00/1548.40/20.80) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 410s ] thds: 16 tps: 1505.99 qps: 1505.99 (r/w/o: 0.00/1485.09/20.90) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 420s ] thds: 16 tps: 1543.59 qps: 1543.59 (r/w/o: 0.00/1519.39/24.20) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 430s ] thds: 16 tps: 1542.91 qps: 1542.91 (r/w/o: 0.00/1521.41/21.50) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 440s ] thds: 16 tps: 1563.50 qps: 1563.50 (r/w/o: 0.00/1540.70/22.80) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 450s ] thds: 16 tps: 1563.90 qps: 1563.90 (r/w/o: 0.00/1543.30/20.60) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 460s ] thds: 16 tps: 1578.00 qps: 1578.00 (r/w/o: 0.00/1556.10/21.90) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 470s ] thds: 16 tps: 1530.00 qps: 1530.00 (r/w/o: 0.00/1505.90/24.10) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 480s ] thds: 16 tps: 1562.50 qps: 1562.50 (r/w/o: 0.00/1541.50/21.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 490s ] thds: 16 tps: 1587.10 qps: 1587.10 (r/w/o: 0.00/1565.70/21.40) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 500s ] thds: 16 tps: 1555.99 qps: 1555.99 (r/w/o: 0.00/1532.49/23.50) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 510s ] thds: 16 tps: 1579.00 qps: 1579.00 (r/w/o: 0.00/1558.30/20.70) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 520s ] thds: 16 tps: 1557.31 qps: 1557.31 (r/w/o: 0.00/1533.11/24.20) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 530s ] thds: 16 tps: 1535.69 qps: 1535.69 (r/w/o: 0.00/1511.59/24.10) lat (ms,95%): 11.45 err/s: 0.00 reconn/s: 0.00
+[ 540s ] thds: 16 tps: 1520.10 qps: 1520.10 (r/w/o: 0.00/1497.40/22.70) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 550s ] thds: 16 tps: 1525.00 qps: 1525.00 (r/w/o: 0.00/1505.60/19.40) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 560s ] thds: 16 tps: 1560.70 qps: 1560.70 (r/w/o: 0.00/1537.00/23.70) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 570s ] thds: 16 tps: 1559.90 qps: 1559.90 (r/w/o: 0.00/1535.80/24.10) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 580s ] thds: 16 tps: 1569.80 qps: 1569.80 (r/w/o: 0.00/1547.40/22.40) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 590s ] thds: 16 tps: 1538.70 qps: 1538.70 (r/w/o: 0.00/1519.00/19.70) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 600s ] thds: 16 tps: 1563.50 qps: 1563.50 (r/w/o: 0.00/1541.70/21.80) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+SQL statistics:
+    queries performed:
+        read:                            0
+        write:                           914344
+        other:                           13190
+        total:                           927534
+    transactions:                        927534 (1545.86 per sec.)
+    queries:                             927534 (1545.86 per sec.)
+    ignored errors:                      0      (0.00 per sec.)
+    reconnects:                          0      (0.00 per sec.)
+
+Throughput:
+    events/s (eps):                      1545.8622
+    time elapsed:                        600.0108s
+    total number of events:              927534
+
+Latency (ms):
+         min:                                    5.01
+         avg:                                   10.35
+         max:                                  339.49
+         95th percentile:                       12.52
+         sum:                              9599586.06
+
+Threads fairness:
+    events (avg/stddev):           57970.8750/337.16
+    execution time (avg/stddev):   599.9741/0.01
+```
+
+Read Only
+```shell
+hanbings@sophgo-farm-entrypoint:~$ ./sysbench --config-file=config oltp_read_only --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
+sysbench 1.1.0-de18a03 (using bundled LuaJIT 2.1.0-beta3)
+
+Running the test with following options:
+Number of threads: 16
+Report intermediate results every 10 second(s)
+Initializing random number generator from current time
+
+
+Initializing worker threads...
+
+Threads started!
+
+[ 10s ] thds: 16 tps: 89.58 qps: 1446.61 (r/w/o: 1266.15/0.00/180.46) lat (ms,95%): 196.89 err/s: 0.00 reconn/s: 0.00
+[ 20s ] thds: 16 tps: 97.00 qps: 1550.14 (r/w/o: 1355.94/0.00/194.21) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 30s ] thds: 16 tps: 96.50 qps: 1546.40 (r/w/o: 1353.40/0.00/193.00) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 40s ] thds: 16 tps: 94.40 qps: 1510.30 (r/w/o: 1321.50/0.00/188.80) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 50s ] thds: 16 tps: 96.10 qps: 1536.70 (r/w/o: 1344.50/0.00/192.20) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 60s ] thds: 16 tps: 97.60 qps: 1560.40 (r/w/o: 1365.40/0.00/195.00) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 70s ] thds: 16 tps: 95.30 qps: 1525.39 (r/w/o: 1334.69/0.00/190.70) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 80s ] thds: 16 tps: 93.50 qps: 1497.20 (r/w/o: 1310.30/0.00/186.90) lat (ms,95%): 183.21 err/s: 0.00 reconn/s: 0.00
+[ 90s ] thds: 16 tps: 94.80 qps: 1514.99 (r/w/o: 1325.29/0.00/189.70) lat (ms,95%): 186.54 err/s: 0.00 reconn/s: 0.00
+[ 100s ] thds: 16 tps: 97.00 qps: 1552.61 (r/w/o: 1358.41/0.00/194.20) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 110s ] thds: 16 tps: 97.20 qps: 1555.10 (r/w/o: 1360.70/0.00/194.40) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 120s ] thds: 16 tps: 98.00 qps: 1567.99 (r/w/o: 1372.00/0.00/196.00) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 130s ] thds: 16 tps: 97.10 qps: 1556.61 (r/w/o: 1362.41/0.00/194.20) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 140s ] thds: 16 tps: 99.00 qps: 1578.30 (r/w/o: 1380.40/0.00/197.90) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 150s ] thds: 16 tps: 97.60 qps: 1566.09 (r/w/o: 1370.79/0.00/195.30) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 160s ] thds: 16 tps: 94.60 qps: 1514.21 (r/w/o: 1325.01/0.00/189.20) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 170s ] thds: 16 tps: 97.70 qps: 1560.80 (r/w/o: 1365.50/0.00/195.30) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 180s ] thds: 16 tps: 99.20 qps: 1584.60 (r/w/o: 1386.10/0.00/198.50) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 190s ] thds: 16 tps: 96.60 qps: 1549.80 (r/w/o: 1356.70/0.00/193.10) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 200s ] thds: 16 tps: 97.40 qps: 1557.49 (r/w/o: 1362.80/0.00/194.70) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 210s ] thds: 16 tps: 99.00 qps: 1582.50 (r/w/o: 1384.40/0.00/198.10) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 220s ] thds: 16 tps: 96.30 qps: 1543.70 (r/w/o: 1351.20/0.00/192.50) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 230s ] thds: 16 tps: 95.40 qps: 1525.40 (r/w/o: 1334.50/0.00/190.90) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 240s ] thds: 16 tps: 99.00 qps: 1581.00 (r/w/o: 1383.00/0.00/198.00) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 250s ] thds: 16 tps: 99.00 qps: 1588.30 (r/w/o: 1390.20/0.00/198.10) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 260s ] thds: 16 tps: 97.00 qps: 1554.70 (r/w/o: 1360.80/0.00/193.90) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 270s ] thds: 16 tps: 96.90 qps: 1546.90 (r/w/o: 1353.20/0.00/193.70) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 280s ] thds: 16 tps: 96.70 qps: 1547.50 (r/w/o: 1353.90/0.00/193.60) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 290s ] thds: 16 tps: 97.60 qps: 1559.30 (r/w/o: 1364.20/0.00/195.10) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 300s ] thds: 16 tps: 97.80 qps: 1565.79 (r/w/o: 1370.19/0.00/195.60) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 310s ] thds: 16 tps: 97.80 qps: 1567.50 (r/w/o: 1371.90/0.00/195.60) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 320s ] thds: 16 tps: 98.20 qps: 1566.90 (r/w/o: 1370.40/0.00/196.50) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 330s ] thds: 16 tps: 99.60 qps: 1595.01 (r/w/o: 1395.80/0.00/199.20) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 340s ] thds: 16 tps: 97.40 qps: 1556.69 (r/w/o: 1361.99/0.00/194.70) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 350s ] thds: 16 tps: 98.40 qps: 1573.91 (r/w/o: 1377.21/0.00/196.70) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 360s ] thds: 16 tps: 99.30 qps: 1591.90 (r/w/o: 1393.20/0.00/198.70) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 370s ] thds: 16 tps: 99.00 qps: 1582.39 (r/w/o: 1384.39/0.00/198.00) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 380s ] thds: 16 tps: 95.00 qps: 1524.01 (r/w/o: 1333.91/0.00/190.10) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 390s ] thds: 16 tps: 97.70 qps: 1559.00 (r/w/o: 1363.90/0.00/195.10) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 400s ] thds: 16 tps: 99.30 qps: 1590.90 (r/w/o: 1392.10/0.00/198.80) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 410s ] thds: 16 tps: 98.40 qps: 1575.29 (r/w/o: 1378.49/0.00/196.80) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 420s ] thds: 16 tps: 98.60 qps: 1577.00 (r/w/o: 1379.70/0.00/197.30) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 430s ] thds: 16 tps: 97.40 qps: 1558.91 (r/w/o: 1364.11/0.00/194.80) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 440s ] thds: 16 tps: 98.30 qps: 1572.10 (r/w/o: 1375.50/0.00/196.60) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 450s ] thds: 16 tps: 99.70 qps: 1592.70 (r/w/o: 1393.50/0.00/199.20) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 460s ] thds: 16 tps: 98.20 qps: 1569.99 (r/w/o: 1373.79/0.00/196.20) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 470s ] thds: 16 tps: 97.30 qps: 1558.80 (r/w/o: 1363.80/0.00/195.00) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 480s ] thds: 16 tps: 98.30 qps: 1569.80 (r/w/o: 1373.30/0.00/196.50) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 490s ] thds: 16 tps: 97.40 qps: 1563.00 (r/w/o: 1368.10/0.00/194.90) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 500s ] thds: 16 tps: 95.10 qps: 1525.00 (r/w/o: 1334.90/0.00/190.10) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 510s ] thds: 16 tps: 94.90 qps: 1512.59 (r/w/o: 1322.69/0.00/189.90) lat (ms,95%): 200.47 err/s: 0.00 reconn/s: 0.00
+[ 520s ] thds: 16 tps: 97.30 qps: 1558.10 (r/w/o: 1363.90/0.00/194.20) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 530s ] thds: 16 tps: 97.80 qps: 1565.50 (r/w/o: 1369.70/0.00/195.80) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 540s ] thds: 16 tps: 97.90 qps: 1567.19 (r/w/o: 1371.39/0.00/195.80) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 550s ] thds: 16 tps: 100.40 qps: 1605.60 (r/w/o: 1404.70/0.00/200.90) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 560s ] thds: 16 tps: 100.00 qps: 1599.10 (r/w/o: 1399.00/0.00/200.10) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 570s ] thds: 16 tps: 100.70 qps: 1613.00 (r/w/o: 1411.60/0.00/201.40) lat (ms,95%): 167.44 err/s: 0.00 reconn/s: 0.00
+[ 580s ] thds: 16 tps: 102.90 qps: 1644.21 (r/w/o: 1438.41/0.00/205.80) lat (ms,95%): 164.45 err/s: 0.00 reconn/s: 0.00
+[ 590s ] thds: 16 tps: 100.60 qps: 1609.80 (r/w/o: 1408.70/0.00/201.10) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 600s ] thds: 16 tps: 99.90 qps: 1599.80 (r/w/o: 1400.20/0.00/199.60) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+SQL statistics:
+    queries performed:
+        read:                            819742
+        write:                           0
+        other:                           117106
+        total:                           936848
+    transactions:                        58553  (97.56 per sec.)
+    queries:                             936848 (1561.00 per sec.)
+    ignored errors:                      0      (0.00 per sec.)
+    reconnects:                          0      (0.00 per sec.)
+
+Throughput:
+    events/s (eps):                      97.5627
+    time elapsed:                        600.1575s
+    total number of events:              58553
+
+Latency (ms):
+         min:                                  141.92
+         avg:                                  163.97
+         max:                                  469.82
+         95th percentile:                      176.73
+         sum:                              9600983.06
+
+Threads fairness:
+    events (avg/stddev):           3659.5625/35.46
+    execution time (avg/stddev):   600.0614/0.06
+```

--- a/sysbench-reports/rvbox13-gcc-riscv64-linux-gnu.md
+++ b/sysbench-reports/rvbox13-gcc-riscv64-linux-gnu.md
@@ -1,0 +1,317 @@
+# RVBox13 gcc-riscv64-linux-gnu 编译器（默认参数）
+
+## 编译
+
+```shell
+$ GOOS=linux GOARCH=riscv64 CC=riscv64-linux-gnu-gcc make server
+```
+
+## 测试
+Point Select
+```shell
+hanbings@sophgo-farm-entrypoint:~$ ./sysbench --config-file=config oltp_point_select --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
+sysbench 1.1.0-de18a03 (using bundled LuaJIT 2.1.0-beta3)
+
+Running the test with following options:
+Number of threads: 16
+Report intermediate results every 10 second(s)
+Initializing random number generator from current time
+
+
+Initializing worker threads...
+
+Threads started!
+
+[ 10s ] thds: 16 tps: 1675.81 qps: 1675.81 (r/w/o: 1675.81/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 20s ] thds: 16 tps: 1622.30 qps: 1622.30 (r/w/o: 1622.30/0.00/0.00) lat (ms,95%): 13.22 err/s: 0.00 reconn/s: 0.00
+[ 30s ] thds: 16 tps: 1680.80 qps: 1680.80 (r/w/o: 1680.80/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 40s ] thds: 16 tps: 1638.60 qps: 1638.60 (r/w/o: 1638.60/0.00/0.00) lat (ms,95%): 12.30 err/s: 0.00 reconn/s: 0.00
+[ 50s ] thds: 16 tps: 1688.39 qps: 1688.39 (r/w/o: 1688.39/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 60s ] thds: 16 tps: 1668.19 qps: 1668.19 (r/w/o: 1668.19/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 70s ] thds: 16 tps: 1671.92 qps: 1671.92 (r/w/o: 1671.92/0.00/0.00) lat (ms,95%): 11.45 err/s: 0.00 reconn/s: 0.00
+[ 80s ] thds: 16 tps: 1586.99 qps: 1586.99 (r/w/o: 1586.99/0.00/0.00) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 90s ] thds: 16 tps: 1701.31 qps: 1701.31 (r/w/o: 1701.31/0.00/0.00) lat (ms,95%): 11.45 err/s: 0.00 reconn/s: 0.00
+[ 100s ] thds: 16 tps: 1715.89 qps: 1715.89 (r/w/o: 1715.89/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 110s ] thds: 16 tps: 1703.11 qps: 1703.11 (r/w/o: 1703.11/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 120s ] thds: 16 tps: 1657.79 qps: 1657.79 (r/w/o: 1657.79/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 130s ] thds: 16 tps: 1677.80 qps: 1677.80 (r/w/o: 1677.80/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 140s ] thds: 16 tps: 1638.60 qps: 1638.60 (r/w/o: 1638.60/0.00/0.00) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 150s ] thds: 16 tps: 1659.40 qps: 1659.40 (r/w/o: 1659.40/0.00/0.00) lat (ms,95%): 11.45 err/s: 0.00 reconn/s: 0.00
+[ 160s ] thds: 16 tps: 1661.00 qps: 1661.00 (r/w/o: 1661.00/0.00/0.00) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+[ 170s ] thds: 16 tps: 1676.30 qps: 1676.30 (r/w/o: 1676.30/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 180s ] thds: 16 tps: 1661.69 qps: 1661.69 (r/w/o: 1661.69/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 190s ] thds: 16 tps: 1670.01 qps: 1670.01 (r/w/o: 1670.01/0.00/0.00) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 200s ] thds: 16 tps: 1668.80 qps: 1668.80 (r/w/o: 1668.80/0.00/0.00) lat (ms,95%): 11.87 err/s: 0.00 reconn/s: 0.00
+[ 210s ] thds: 16 tps: 1665.40 qps: 1665.40 (r/w/o: 1665.40/0.00/0.00) lat (ms,95%): 11.87 err/s: 0.00 reconn/s: 0.00
+[ 220s ] thds: 16 tps: 1655.60 qps: 1655.60 (r/w/o: 1655.60/0.00/0.00) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+[ 230s ] thds: 16 tps: 1667.10 qps: 1667.10 (r/w/o: 1667.10/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 240s ] thds: 16 tps: 1681.50 qps: 1681.50 (r/w/o: 1681.50/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 250s ] thds: 16 tps: 1664.60 qps: 1664.60 (r/w/o: 1664.60/0.00/0.00) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 260s ] thds: 16 tps: 1625.90 qps: 1625.90 (r/w/o: 1625.90/0.00/0.00) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 270s ] thds: 16 tps: 1613.10 qps: 1613.10 (r/w/o: 1613.10/0.00/0.00) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 280s ] thds: 16 tps: 1658.01 qps: 1658.01 (r/w/o: 1658.01/0.00/0.00) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 290s ] thds: 16 tps: 1662.80 qps: 1662.80 (r/w/o: 1662.80/0.00/0.00) lat (ms,95%): 11.24 err/s: 0.00 reconn/s: 0.00
+[ 300s ] thds: 16 tps: 1685.30 qps: 1685.30 (r/w/o: 1685.30/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 310s ] thds: 16 tps: 1656.49 qps: 1656.49 (r/w/o: 1656.49/0.00/0.00) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+[ 320s ] thds: 16 tps: 1690.31 qps: 1690.31 (r/w/o: 1690.31/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 330s ] thds: 16 tps: 1665.10 qps: 1665.10 (r/w/o: 1665.10/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 340s ] thds: 16 tps: 1675.49 qps: 1675.49 (r/w/o: 1675.49/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 350s ] thds: 16 tps: 1641.01 qps: 1641.01 (r/w/o: 1641.01/0.00/0.00) lat (ms,95%): 12.08 err/s: 0.00 reconn/s: 0.00
+[ 360s ] thds: 16 tps: 1688.40 qps: 1688.40 (r/w/o: 1688.40/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 370s ] thds: 16 tps: 1653.70 qps: 1653.70 (r/w/o: 1653.70/0.00/0.00) lat (ms,95%): 11.65 err/s: 0.00 reconn/s: 0.00
+[ 380s ] thds: 16 tps: 1472.90 qps: 1472.90 (r/w/o: 1472.90/0.00/0.00) lat (ms,95%): 18.95 err/s: 0.00 reconn/s: 0.00
+[ 390s ] thds: 16 tps: 1658.69 qps: 1658.69 (r/w/o: 1658.69/0.00/0.00) lat (ms,95%): 11.45 err/s: 0.00 reconn/s: 0.00
+[ 400s ] thds: 16 tps: 1654.40 qps: 1654.40 (r/w/o: 1654.40/0.00/0.00) lat (ms,95%): 11.87 err/s: 0.00 reconn/s: 0.00
+[ 410s ] thds: 16 tps: 1672.01 qps: 1672.01 (r/w/o: 1672.01/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 420s ] thds: 16 tps: 1690.10 qps: 1690.10 (r/w/o: 1690.10/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 430s ] thds: 16 tps: 1701.60 qps: 1701.60 (r/w/o: 1701.60/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 440s ] thds: 16 tps: 1702.90 qps: 1702.90 (r/w/o: 1702.90/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 450s ] thds: 16 tps: 1691.80 qps: 1691.80 (r/w/o: 1691.80/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 460s ] thds: 16 tps: 1704.30 qps: 1704.30 (r/w/o: 1704.30/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 470s ] thds: 16 tps: 1672.80 qps: 1672.80 (r/w/o: 1672.80/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 480s ] thds: 16 tps: 1694.80 qps: 1694.80 (r/w/o: 1694.80/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 490s ] thds: 16 tps: 1693.40 qps: 1693.40 (r/w/o: 1693.40/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 500s ] thds: 16 tps: 1680.60 qps: 1680.60 (r/w/o: 1680.60/0.00/0.00) lat (ms,95%): 11.04 err/s: 0.00 reconn/s: 0.00
+[ 510s ] thds: 16 tps: 1680.10 qps: 1680.10 (r/w/o: 1680.10/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 520s ] thds: 16 tps: 1614.70 qps: 1614.70 (r/w/o: 1614.70/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 530s ] thds: 16 tps: 1615.99 qps: 1615.99 (r/w/o: 1615.99/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 540s ] thds: 16 tps: 1720.01 qps: 1720.01 (r/w/o: 1720.01/0.00/0.00) lat (ms,95%): 10.46 err/s: 0.00 reconn/s: 0.00
+[ 550s ] thds: 16 tps: 1723.30 qps: 1723.30 (r/w/o: 1723.30/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 560s ] thds: 16 tps: 1716.30 qps: 1716.30 (r/w/o: 1716.30/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 570s ] thds: 16 tps: 1698.70 qps: 1698.70 (r/w/o: 1698.70/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 580s ] thds: 16 tps: 1683.39 qps: 1683.39 (r/w/o: 1683.39/0.00/0.00) lat (ms,95%): 10.65 err/s: 0.00 reconn/s: 0.00
+[ 590s ] thds: 16 tps: 1680.91 qps: 1680.91 (r/w/o: 1680.91/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+[ 600s ] thds: 16 tps: 1677.50 qps: 1677.50 (r/w/o: 1677.50/0.00/0.00) lat (ms,95%): 10.84 err/s: 0.00 reconn/s: 0.00
+SQL statistics:
+    queries performed:
+        read:                            1000776
+        write:                           0
+        other:                           0
+        total:                           1000776
+    transactions:                        1000776 (1667.92 per sec.)
+    queries:                             1000776 (1667.92 per sec.)
+    ignored errors:                      0      (0.00 per sec.)
+    reconnects:                          0      (0.00 per sec.)
+
+Throughput:
+    events/s (eps):                      1667.9222
+    time elapsed:                        600.0136s
+    total number of events:              1000776
+
+Latency (ms):
+         min:                                    5.18
+         avg:                                    9.59
+         max:                                  222.04
+         95th percentile:                       11.04
+         sum:                              9599602.12
+
+Threads fairness:
+    events (avg/stddev):           62548.5000/5915.59
+    execution time (avg/stddev):   599.9751/0.02
+```
+
+Update Index
+```shell
+hanbings@sophgo-farm-entrypoint:~$ ./sysbench --config-file=config oltp_update_index --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
+sysbench 1.1.0-de18a03 (using bundled LuaJIT 2.1.0-beta3)
+
+Running the test with following options:
+Number of threads: 16
+Report intermediate results every 10 second(s)
+Initializing random number generator from current time
+
+
+Initializing worker threads...
+
+Threads started!
+
+[ 10s ] thds: 16 tps: 1513.63 qps: 1513.63 (r/w/o: 0.00/1491.94/21.70) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 20s ] thds: 16 tps: 1493.10 qps: 1493.10 (r/w/o: 0.00/1471.10/22.00) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 30s ] thds: 16 tps: 1507.51 qps: 1507.51 (r/w/o: 0.00/1485.91/21.60) lat (ms,95%): 13.22 err/s: 0.00 reconn/s: 0.00
+[ 40s ] thds: 16 tps: 1534.39 qps: 1534.39 (r/w/o: 0.00/1511.79/22.60) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 50s ] thds: 16 tps: 1523.60 qps: 1523.60 (r/w/o: 0.00/1499.00/24.60) lat (ms,95%): 12.98 err/s: 0.00 reconn/s: 0.00
+[ 60s ] thds: 16 tps: 1545.80 qps: 1545.80 (r/w/o: 0.00/1522.40/23.40) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 70s ] thds: 16 tps: 1436.60 qps: 1436.60 (r/w/o: 0.00/1414.40/22.20) lat (ms,95%): 15.00 err/s: 0.00 reconn/s: 0.00
+[ 80s ] thds: 16 tps: 1433.10 qps: 1433.10 (r/w/o: 0.00/1412.20/20.90) lat (ms,95%): 15.27 err/s: 0.00 reconn/s: 0.00
+[ 90s ] thds: 16 tps: 1285.10 qps: 1285.10 (r/w/o: 0.00/1266.20/18.90) lat (ms,95%): 20.37 err/s: 0.00 reconn/s: 0.00
+[ 100s ] thds: 16 tps: 1134.50 qps: 1134.50 (r/w/o: 0.00/1117.00/17.50) lat (ms,95%): 21.89 err/s: 0.00 reconn/s: 0.00
+[ 110s ] thds: 16 tps: 1353.69 qps: 1353.69 (r/w/o: 0.00/1333.49/20.20) lat (ms,95%): 17.32 err/s: 0.00 reconn/s: 0.00
+[ 120s ] thds: 16 tps: 1300.91 qps: 1300.91 (r/w/o: 0.00/1283.11/17.80) lat (ms,95%): 20.00 err/s: 0.00 reconn/s: 0.00
+[ 130s ] thds: 16 tps: 1296.50 qps: 1296.50 (r/w/o: 0.00/1277.00/19.50) lat (ms,95%): 19.65 err/s: 0.00 reconn/s: 0.00
+[ 140s ] thds: 16 tps: 1222.90 qps: 1222.90 (r/w/o: 0.00/1204.80/18.10) lat (ms,95%): 21.50 err/s: 0.00 reconn/s: 0.00
+[ 150s ] thds: 16 tps: 1304.29 qps: 1304.29 (r/w/o: 0.00/1284.79/19.50) lat (ms,95%): 21.50 err/s: 0.00 reconn/s: 0.00
+[ 160s ] thds: 16 tps: 1213.91 qps: 1213.91 (r/w/o: 0.00/1194.81/19.10) lat (ms,95%): 25.28 err/s: 0.00 reconn/s: 0.00
+[ 170s ] thds: 16 tps: 629.70 qps: 629.70 (r/w/o: 0.00/619.80/9.90) lat (ms,95%): 57.87 err/s: 0.00 reconn/s: 0.00
+[ 180s ] thds: 16 tps: 781.60 qps: 781.60 (r/w/o: 0.00/770.70/10.90) lat (ms,95%): 35.59 err/s: 0.00 reconn/s: 0.00
+[ 190s ] thds: 16 tps: 908.90 qps: 908.90 (r/w/o: 0.00/898.60/10.30) lat (ms,95%): 28.67 err/s: 0.00 reconn/s: 0.00
+[ 200s ] thds: 16 tps: 1045.00 qps: 1045.00 (r/w/o: 0.00/1028.50/16.50) lat (ms,95%): 22.69 err/s: 0.00 reconn/s: 0.00
+[ 210s ] thds: 16 tps: 1123.10 qps: 1123.10 (r/w/o: 0.00/1105.40/17.70) lat (ms,95%): 20.74 err/s: 0.00 reconn/s: 0.00
+[ 220s ] thds: 16 tps: 1001.80 qps: 1001.80 (r/w/o: 0.00/988.20/13.60) lat (ms,95%): 41.10 err/s: 0.00 reconn/s: 0.00
+[ 230s ] thds: 16 tps: 420.50 qps: 420.50 (r/w/o: 0.00/415.40/5.10) lat (ms,95%): 75.82 err/s: 0.00 reconn/s: 0.00
+[ 240s ] thds: 16 tps: 613.60 qps: 613.60 (r/w/o: 0.00/603.50/10.10) lat (ms,95%): 44.17 err/s: 0.00 reconn/s: 0.00
+[ 250s ] thds: 16 tps: 732.90 qps: 732.90 (r/w/o: 0.00/722.50/10.40) lat (ms,95%): 50.11 err/s: 0.00 reconn/s: 0.00
+[ 260s ] thds: 16 tps: 1072.20 qps: 1072.20 (r/w/o: 0.00/1055.50/16.70) lat (ms,95%): 23.95 err/s: 0.00 reconn/s: 0.00
+[ 270s ] thds: 16 tps: 852.20 qps: 852.20 (r/w/o: 0.00/840.60/11.60) lat (ms,95%): 47.47 err/s: 0.00 reconn/s: 0.00
+[ 280s ] thds: 16 tps: 428.00 qps: 428.00 (r/w/o: 0.00/421.60/6.40) lat (ms,95%): 65.65 err/s: 0.00 reconn/s: 0.00
+[ 290s ] thds: 16 tps: 977.20 qps: 977.20 (r/w/o: 0.00/962.10/15.10) lat (ms,95%): 48.34 err/s: 0.00 reconn/s: 0.00
+[ 300s ] thds: 16 tps: 1220.20 qps: 1220.20 (r/w/o: 0.00/1204.20/16.00) lat (ms,95%): 20.74 err/s: 0.00 reconn/s: 0.00
+[ 310s ] thds: 16 tps: 1046.10 qps: 1046.10 (r/w/o: 0.00/1029.10/17.00) lat (ms,95%): 33.72 err/s: 0.00 reconn/s: 0.00
+[ 320s ] thds: 16 tps: 1142.10 qps: 1142.10 (r/w/o: 0.00/1125.80/16.30) lat (ms,95%): 23.52 err/s: 0.00 reconn/s: 0.00
+[ 330s ] thds: 16 tps: 1060.20 qps: 1060.20 (r/w/o: 0.00/1043.00/17.20) lat (ms,95%): 28.67 err/s: 0.00 reconn/s: 0.00
+[ 340s ] thds: 16 tps: 978.80 qps: 978.80 (r/w/o: 0.00/964.00/14.80) lat (ms,95%): 28.16 err/s: 0.00 reconn/s: 0.00
+[ 350s ] thds: 16 tps: 431.20 qps: 431.20 (r/w/o: 0.00/425.70/5.50) lat (ms,95%): 66.84 err/s: 0.00 reconn/s: 0.00
+[ 360s ] thds: 16 tps: 463.00 qps: 463.00 (r/w/o: 0.00/456.10/6.90) lat (ms,95%): 59.99 err/s: 0.00 reconn/s: 0.00
+[ 370s ] thds: 16 tps: 626.80 qps: 626.80 (r/w/o: 0.00/617.30/9.50) lat (ms,95%): 62.19 err/s: 0.00 reconn/s: 0.00
+[ 380s ] thds: 16 tps: 537.60 qps: 537.60 (r/w/o: 0.00/530.50/7.10) lat (ms,95%): 52.89 err/s: 0.00 reconn/s: 0.00
+[ 390s ] thds: 16 tps: 321.30 qps: 321.30 (r/w/o: 0.00/317.00/4.30) lat (ms,95%): 87.56 err/s: 0.00 reconn/s: 0.00
+[ 400s ] thds: 16 tps: 392.70 qps: 392.70 (r/w/o: 0.00/387.20/5.50) lat (ms,95%): 77.19 err/s: 0.00 reconn/s: 0.00
+[ 410s ] thds: 16 tps: 541.70 qps: 541.70 (r/w/o: 0.00/532.10/9.60) lat (ms,95%): 75.82 err/s: 0.00 reconn/s: 0.00
+[ 420s ] thds: 16 tps: 1165.00 qps: 1165.00 (r/w/o: 0.00/1151.70/13.30) lat (ms,95%): 22.28 err/s: 0.00 reconn/s: 0.00
+[ 430s ] thds: 16 tps: 982.70 qps: 982.70 (r/w/o: 0.00/969.50/13.20) lat (ms,95%): 27.17 err/s: 0.00 reconn/s: 0.00
+[ 440s ] thds: 16 tps: 418.60 qps: 418.60 (r/w/o: 0.00/412.90/5.70) lat (ms,95%): 66.84 err/s: 0.00 reconn/s: 0.00
+[ 450s ] thds: 16 tps: 535.70 qps: 535.70 (r/w/o: 0.00/528.40/7.30) lat (ms,95%): 66.84 err/s: 0.00 reconn/s: 0.00
+[ 460s ] thds: 16 tps: 1196.90 qps: 1196.90 (r/w/o: 0.00/1181.80/15.10) lat (ms,95%): 24.38 err/s: 0.00 reconn/s: 0.00
+[ 470s ] thds: 16 tps: 1466.39 qps: 1466.39 (r/w/o: 0.00/1446.79/19.60) lat (ms,95%): 14.46 err/s: 0.00 reconn/s: 0.00
+[ 480s ] thds: 16 tps: 1474.70 qps: 1474.70 (r/w/o: 0.00/1451.10/23.60) lat (ms,95%): 13.95 err/s: 0.00 reconn/s: 0.00
+[ 490s ] thds: 16 tps: 1471.00 qps: 1471.00 (r/w/o: 0.00/1449.30/21.70) lat (ms,95%): 13.95 err/s: 0.00 reconn/s: 0.00
+[ 500s ] thds: 16 tps: 1162.40 qps: 1162.40 (r/w/o: 0.00/1145.90/16.50) lat (ms,95%): 21.50 err/s: 0.00 reconn/s: 0.00
+[ 510s ] thds: 16 tps: 1298.89 qps: 1298.89 (r/w/o: 0.00/1280.49/18.40) lat (ms,95%): 19.29 err/s: 0.00 reconn/s: 0.00
+[ 520s ] thds: 16 tps: 1405.10 qps: 1405.10 (r/w/o: 0.00/1386.10/19.00) lat (ms,95%): 16.12 err/s: 0.00 reconn/s: 0.00
+[ 530s ] thds: 16 tps: 1500.71 qps: 1500.71 (r/w/o: 0.00/1478.01/22.70) lat (ms,95%): 12.75 err/s: 0.00 reconn/s: 0.00
+[ 540s ] thds: 16 tps: 1531.10 qps: 1531.10 (r/w/o: 0.00/1508.70/22.40) lat (ms,95%): 12.52 err/s: 0.00 reconn/s: 0.00
+[ 550s ] thds: 16 tps: 1433.40 qps: 1433.40 (r/w/o: 0.00/1414.50/18.90) lat (ms,95%): 15.55 err/s: 0.00 reconn/s: 0.00
+[ 560s ] thds: 16 tps: 1421.70 qps: 1421.70 (r/w/o: 0.00/1400.50/21.20) lat (ms,95%): 15.83 err/s: 0.00 reconn/s: 0.00
+[ 570s ] thds: 16 tps: 1441.80 qps: 1441.80 (r/w/o: 0.00/1419.50/22.30) lat (ms,95%): 13.95 err/s: 0.00 reconn/s: 0.00
+[ 580s ] thds: 16 tps: 1381.40 qps: 1381.40 (r/w/o: 0.00/1361.70/19.70) lat (ms,95%): 17.63 err/s: 0.00 reconn/s: 0.00
+[ 590s ] thds: 16 tps: 1482.90 qps: 1482.90 (r/w/o: 0.00/1463.20/19.70) lat (ms,95%): 13.46 err/s: 0.00 reconn/s: 0.00
+[ 600s ] thds: 16 tps: 1431.09 qps: 1431.09 (r/w/o: 0.00/1408.29/22.80) lat (ms,95%): 14.73 err/s: 0.00 reconn/s: 0.00
+SQL statistics:
+    queries performed:
+        read:                            0
+        write:                           646946
+        other:                           9567
+        total:                           656513
+    transactions:                        656513 (1094.17 per sec.)
+    queries:                             656513 (1094.17 per sec.)
+    ignored errors:                      0      (0.00 per sec.)
+    reconnects:                          0      (0.00 per sec.)
+
+Throughput:
+    events/s (eps):                      1094.1653
+    time elapsed:                        600.0126s
+    total number of events:              656513
+
+Latency (ms):
+         min:                                    5.53
+         avg:                                   14.62
+         max:                                  187.25
+         95th percentile:                       31.94
+         sum:                              9599726.80
+
+Threads fairness:
+    events (avg/stddev):           41032.0625/778.74
+    execution time (avg/stddev):   599.9829/0.01
+```
+
+Read Only
+```shell
+hanbings@sophgo-farm-entrypoint:~$ ./sysbench --config-file=config oltp_read_only --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
+sysbench 1.1.0-de18a03 (using bundled LuaJIT 2.1.0-beta3)
+
+Running the test with following options:
+Number of threads: 16
+Report intermediate results every 10 second(s)
+Initializing random number generator from current time
+
+
+Initializing worker threads...
+
+Threads started!
+
+[ 10s ] thds: 16 tps: 81.68 qps: 1324.33 (r/w/o: 1159.37/0.00/164.97) lat (ms,95%): 292.60 err/s: 0.00 reconn/s: 0.00
+[ 20s ] thds: 16 tps: 76.90 qps: 1222.83 (r/w/o: 1069.12/0.00/153.70) lat (ms,95%): 314.45 err/s: 0.00 reconn/s: 0.00
+[ 30s ] thds: 16 tps: 78.80 qps: 1262.81 (r/w/o: 1105.21/0.00/157.60) lat (ms,95%): 308.84 err/s: 0.00 reconn/s: 0.00
+[ 40s ] thds: 16 tps: 44.90 qps: 717.80 (r/w/o: 627.90/0.00/89.90) lat (ms,95%): 646.19 err/s: 0.00 reconn/s: 0.00
+[ 50s ] thds: 16 tps: 64.60 qps: 1033.20 (r/w/o: 904.20/0.00/129.00) lat (ms,95%): 411.96 err/s: 0.00 reconn/s: 0.00
+[ 60s ] thds: 16 tps: 88.80 qps: 1419.70 (r/w/o: 1241.90/0.00/177.80) lat (ms,95%): 257.95 err/s: 0.00 reconn/s: 0.00
+[ 70s ] thds: 16 tps: 87.30 qps: 1402.20 (r/w/o: 1227.80/0.00/174.40) lat (ms,95%): 262.64 err/s: 0.00 reconn/s: 0.00
+[ 80s ] thds: 16 tps: 73.10 qps: 1164.90 (r/w/o: 1018.50/0.00/146.40) lat (ms,95%): 344.08 err/s: 0.00 reconn/s: 0.00
+[ 90s ] thds: 16 tps: 83.20 qps: 1335.89 (r/w/o: 1169.49/0.00/166.40) lat (ms,95%): 240.02 err/s: 0.00 reconn/s: 0.00
+[ 100s ] thds: 16 tps: 69.10 qps: 1104.71 (r/w/o: 966.61/0.00/138.10) lat (ms,95%): 458.96 err/s: 0.00 reconn/s: 0.00
+[ 110s ] thds: 16 tps: 90.30 qps: 1446.20 (r/w/o: 1265.60/0.00/180.60) lat (ms,95%): 223.34 err/s: 0.00 reconn/s: 0.00
+[ 120s ] thds: 16 tps: 72.00 qps: 1149.90 (r/w/o: 1005.80/0.00/144.10) lat (ms,95%): 314.45 err/s: 0.00 reconn/s: 0.00
+[ 130s ] thds: 16 tps: 24.00 qps: 378.40 (r/w/o: 330.50/0.00/47.90) lat (ms,95%): 1032.01 err/s: 0.00 reconn/s: 0.00
+[ 140s ] thds: 16 tps: 14.20 qps: 223.00 (r/w/o: 195.30/0.00/27.70) lat (ms,95%): 1561.52 err/s: 0.00 reconn/s: 0.00
+[ 150s ] thds: 16 tps: 13.00 qps: 209.90 (r/w/o: 183.10/0.00/26.80) lat (ms,95%): 1739.68 err/s: 0.00 reconn/s: 0.00
+[ 160s ] thds: 16 tps: 14.40 qps: 237.50 (r/w/o: 208.70/0.00/28.80) lat (ms,95%): 1506.29 err/s: 0.00 reconn/s: 0.00
+[ 170s ] thds: 16 tps: 17.60 qps: 275.10 (r/w/o: 239.90/0.00/35.20) lat (ms,95%): 1771.29 err/s: 0.00 reconn/s: 0.00
+[ 180s ] thds: 16 tps: 51.70 qps: 838.10 (r/w/o: 734.70/0.00/103.40) lat (ms,95%): 759.88 err/s: 0.00 reconn/s: 0.00
+[ 190s ] thds: 16 tps: 65.80 qps: 1050.90 (r/w/o: 919.30/0.00/131.60) lat (ms,95%): 363.18 err/s: 0.00 reconn/s: 0.00
+[ 200s ] thds: 16 tps: 72.90 qps: 1166.40 (r/w/o: 1020.80/0.00/145.60) lat (ms,95%): 350.33 err/s: 0.00 reconn/s: 0.00
+[ 210s ] thds: 16 tps: 80.10 qps: 1282.20 (r/w/o: 1121.90/0.00/160.30) lat (ms,95%): 325.98 err/s: 0.00 reconn/s: 0.00
+[ 220s ] thds: 16 tps: 66.10 qps: 1057.80 (r/w/o: 925.50/0.00/132.30) lat (ms,95%): 376.49 err/s: 0.00 reconn/s: 0.00
+[ 230s ] thds: 16 tps: 44.50 qps: 711.80 (r/w/o: 622.80/0.00/89.00) lat (ms,95%): 733.00 err/s: 0.00 reconn/s: 0.00
+[ 240s ] thds: 16 tps: 35.20 qps: 560.00 (r/w/o: 489.60/0.00/70.40) lat (ms,95%): 746.32 err/s: 0.00 reconn/s: 0.00
+[ 250s ] thds: 16 tps: 73.60 qps: 1175.90 (r/w/o: 1028.90/0.00/147.00) lat (ms,95%): 363.18 err/s: 0.00 reconn/s: 0.00
+[ 260s ] thds: 16 tps: 87.10 qps: 1396.10 (r/w/o: 1221.70/0.00/174.40) lat (ms,95%): 244.38 err/s: 0.00 reconn/s: 0.00
+[ 270s ] thds: 16 tps: 49.10 qps: 786.40 (r/w/o: 688.40/0.00/98.00) lat (ms,95%): 816.63 err/s: 0.00 reconn/s: 0.00
+[ 280s ] thds: 16 tps: 18.00 qps: 288.60 (r/w/o: 252.40/0.00/36.20) lat (ms,95%): 1258.08 err/s: 0.00 reconn/s: 0.00
+[ 290s ] thds: 16 tps: 23.60 qps: 378.40 (r/w/o: 331.20/0.00/47.20) lat (ms,95%): 1069.86 err/s: 0.00 reconn/s: 0.00
+[ 300s ] thds: 16 tps: 40.20 qps: 641.89 (r/w/o: 561.60/0.00/80.30) lat (ms,95%): 590.56 err/s: 0.00 reconn/s: 0.00
+[ 310s ] thds: 16 tps: 27.30 qps: 433.60 (r/w/o: 379.10/0.00/54.50) lat (ms,95%): 1170.65 err/s: 0.00 reconn/s: 0.00
+[ 320s ] thds: 16 tps: 16.90 qps: 277.50 (r/w/o: 243.50/0.00/34.00) lat (ms,95%): 1427.08 err/s: 0.00 reconn/s: 0.00
+[ 330s ] thds: 16 tps: 37.70 qps: 599.70 (r/w/o: 524.30/0.00/75.40) lat (ms,95%): 1129.24 err/s: 0.00 reconn/s: 0.00
+[ 340s ] thds: 16 tps: 71.10 qps: 1136.00 (r/w/o: 993.80/0.00/142.20) lat (ms,95%): 434.83 err/s: 0.00 reconn/s: 0.00
+[ 350s ] thds: 16 tps: 95.70 qps: 1529.20 (r/w/o: 1337.90/0.00/191.30) lat (ms,95%): 189.93 err/s: 0.00 reconn/s: 0.00
+[ 360s ] thds: 16 tps: 80.90 qps: 1295.90 (r/w/o: 1134.00/0.00/161.90) lat (ms,95%): 539.71 err/s: 0.00 reconn/s: 0.00
+[ 370s ] thds: 16 tps: 98.60 qps: 1579.39 (r/w/o: 1382.19/0.00/197.20) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 380s ] thds: 16 tps: 96.70 qps: 1547.61 (r/w/o: 1354.41/0.00/193.20) lat (ms,95%): 183.21 err/s: 0.00 reconn/s: 0.00
+[ 390s ] thds: 16 tps: 75.40 qps: 1204.30 (r/w/o: 1053.40/0.00/150.90) lat (ms,95%): 475.79 err/s: 0.00 reconn/s: 0.00
+[ 400s ] thds: 16 tps: 93.20 qps: 1492.10 (r/w/o: 1305.60/0.00/186.50) lat (ms,95%): 189.93 err/s: 0.00 reconn/s: 0.00
+[ 410s ] thds: 16 tps: 90.40 qps: 1444.60 (r/w/o: 1263.80/0.00/180.80) lat (ms,95%): 215.44 err/s: 0.00 reconn/s: 0.00
+[ 420s ] thds: 16 tps: 95.00 qps: 1516.91 (r/w/o: 1327.10/0.00/189.80) lat (ms,95%): 196.89 err/s: 0.00 reconn/s: 0.00
+[ 430s ] thds: 16 tps: 93.20 qps: 1492.80 (r/w/o: 1306.40/0.00/186.40) lat (ms,95%): 189.93 err/s: 0.00 reconn/s: 0.00
+[ 440s ] thds: 16 tps: 97.30 qps: 1557.10 (r/w/o: 1362.40/0.00/194.70) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 450s ] thds: 16 tps: 96.60 qps: 1546.70 (r/w/o: 1353.50/0.00/193.20) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 460s ] thds: 16 tps: 98.50 qps: 1577.50 (r/w/o: 1380.40/0.00/197.10) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 470s ] thds: 16 tps: 99.50 qps: 1592.79 (r/w/o: 1393.89/0.00/198.90) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 480s ] thds: 16 tps: 99.60 qps: 1594.20 (r/w/o: 1394.90/0.00/199.30) lat (ms,95%): 173.58 err/s: 0.00 reconn/s: 0.00
+[ 490s ] thds: 16 tps: 99.90 qps: 1599.09 (r/w/o: 1399.39/0.00/199.70) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 500s ] thds: 16 tps: 98.80 qps: 1580.92 (r/w/o: 1383.21/0.00/197.70) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 510s ] thds: 16 tps: 98.90 qps: 1580.89 (r/w/o: 1383.09/0.00/197.80) lat (ms,95%): 176.73 err/s: 0.00 reconn/s: 0.00
+[ 520s ] thds: 16 tps: 94.90 qps: 1516.21 (r/w/o: 1326.51/0.00/189.70) lat (ms,95%): 240.02 err/s: 0.00 reconn/s: 0.00
+[ 530s ] thds: 16 tps: 97.90 qps: 1566.30 (r/w/o: 1370.50/0.00/195.80) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 540s ] thds: 16 tps: 94.50 qps: 1515.41 (r/w/o: 1326.31/0.00/189.10) lat (ms,95%): 183.21 err/s: 0.00 reconn/s: 0.00
+[ 550s ] thds: 16 tps: 98.00 qps: 1567.79 (r/w/o: 1371.79/0.00/196.00) lat (ms,95%): 183.21 err/s: 0.00 reconn/s: 0.00
+[ 560s ] thds: 16 tps: 99.20 qps: 1583.60 (r/w/o: 1385.20/0.00/198.40) lat (ms,95%): 170.48 err/s: 0.00 reconn/s: 0.00
+[ 570s ] thds: 16 tps: 96.90 qps: 1550.10 (r/w/o: 1356.40/0.00/193.70) lat (ms,95%): 179.94 err/s: 0.00 reconn/s: 0.00
+[ 580s ] thds: 16 tps: 95.90 qps: 1536.00 (r/w/o: 1344.20/0.00/191.80) lat (ms,95%): 189.93 err/s: 0.00 reconn/s: 0.00
+[ 590s ] thds: 16 tps: 95.30 qps: 1524.80 (r/w/o: 1334.30/0.00/190.50) lat (ms,95%): 193.38 err/s: 0.00 reconn/s: 0.00
+[ 600s ] thds: 16 tps: 96.10 qps: 1537.70 (r/w/o: 1345.30/0.00/192.40) lat (ms,95%): 183.21 err/s: 0.00 reconn/s: 0.00
+SQL statistics:
+    queries performed:
+        read:                            606662
+        write:                           0
+        other:                           86666
+        total:                           693328
+    transactions:                        43333  (72.20 per sec.)
+    queries:                             693328 (1155.27 per sec.)
+    ignored errors:                      0      (0.00 per sec.)
+    reconnects:                          0      (0.00 per sec.)
+
+Throughput:
+    events/s (eps):                      72.2042
+    time elapsed:                        600.1454s
+    total number of events:              43333
+
+Latency (ms):
+         min:                                  141.79
+         avg:                                  221.57
+         max:                                 2018.17
+         95th percentile:                      511.33
+         sum:                              9601205.04
+
+Threads fairness:
+    events (avg/stddev):           2708.3125/26.93
+    execution time (avg/stddev):   600.0753/0.05
+```

--- a/sysbench_autobench.py
+++ b/sysbench_autobench.py
@@ -1,0 +1,95 @@
+#!/bin/python3
+import os
+import subprocess
+import time
+import csv
+import re
+import sys
+
+sysbench_path = os.getenv('SYSBENCH_PATH', "sysbench")
+
+benches = sys.argv
+benches.pop(0)
+
+config = {
+    "threads": os.getenv("THREADS", "32"),
+    "mysql-host": os.getenv("MYSQL_HOST", "127.0.0.1"),
+    "mysql-port": os.getenv("MYSQL_PORT", "3306"),
+    "mysql-user": os.getenv("MYSQL_USER", "root"),
+    "mysql-password": os.getenv("MYSQL_PASSWORD", ""),
+    "mysql-db": os.getenv("MYSQL_DB", "sbtest"),
+    "time": os.getenv("BENCHMARK_TIME", "600"),
+    "report-interval": os.getenv("REPORT_INTERVAL", "10"),
+    "db-driver": "mysql",
+}
+
+def run_bench(config, test):
+    with open('config', 'w', newline='') as file: 
+        config_str = ""
+        for key in config.keys():
+            config_str += "%s=%s\n" % (key, config[key])
+        file.write(config_str)
+        
+    process = subprocess.Popen([sysbench_path, "--config-file=config", test,"--tables=32","--table-size=1000000","--db-ps-mode=auto","--rand-type=uniform", "run"],
+                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    
+    final_data = None
+    error = False
+    while True:
+        out = process.stdout.readline()
+        if not out: break
+        string = out.decode('utf-8').strip()
+        if string.startswith('['): print(string)
+        if string.startswith('FATAL'): 
+            print("\033[91m%s\033[0m" % string) 
+            error = True
+        if string == "SQL statistics:": break
+        
+        
+    if error: raise Exception("\033[91mSysbench exit with error.\033[0m")
+        
+    string = "".join(iter(lambda: process.stdout.readline().decode('utf-8'), ""))
+    non_spaced = string.replace(' ','')
+    
+    total_time = float(re.findall("(?<=totaltime:)[0-9.]*",non_spaced)[0])
+    
+    parsed_data = {
+        "tps": round(float(re.findall(r"(?<=transactions:)[0-9.]*", non_spaced)[0]) / total_time, 2),
+        "qps": round(float(re.findall(r"(?<=queries:)[0-9.]*", non_spaced)[0]) / total_time, 2), 
+        "qpf": {
+            "read": int(re.findall(r"(?<=read:)[0-9.]*", non_spaced)[0]), 
+            "write": int(re.findall(r"(?<=write:)[0-9.]*", non_spaced)[0]) ,
+            "other": int(re.findall(r"(?<=other:)[0-9.]*", non_spaced)[0]), 
+            "total": int(re.findall(r"(?<=total:)[0-9.]*", non_spaced)[0]),
+        }, 
+        "lat": float(re.findall(r"(?<=95thpercentile:)[0-9.]*", non_spaced)[0]), 
+        "err": int(re.findall(r"(?<=ignorederrors:)[0-9]*", non_spaced)[0]), 
+        "reconn": int(re.findall(r"(?<=reconnects:)[0-9]*", non_spaced)[0]),
+        "events": float(re.findall(r"(?<=events\(avg/stddev\):)[0-9.]*", non_spaced)[0]), 
+        "exectime": float(re.findall(r"(?<=executiontime\(avg/stddev\):)[0-9.]*", non_spaced)[0])
+    }
+
+    return parsed_data
+
+
+if __name__ == "__main__":
+    results = []
+    for bench in benches:
+        print("Benchmarking %s with %s threads..." % (bench,config["threads"]))
+        results.append((bench,run_bench(config, bench)))
+    
+    with open('results-t%s.csv' % config["threads"], 'w', newline='') as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(['Benchmark','Transactions per second', 'Queries per second', 'Queries performed', 'Read queries performed','Write queries performed','Other queries performed', 'Latency(95%)', 'Ignored errors/s', 'Reconnects/s','Events(Threads fairness)', 'Execution time(Threads fairness)'])
+        
+        for (bench, res) in results:
+            writer.writerow([bench,res["tps"], res["qps"], 
+                                res["qpf"]["total"], 
+                                res["qpf"]["read"], 
+                                res["qpf"]["write"], 
+                                res["qpf"]["other"], 
+                                res["lat"], 
+                                res["err"], 
+                                res["reconn"],
+                                res["events"],
+                                res["exectime"]])

--- a/sysbench_autobench_powers.py
+++ b/sysbench_autobench_powers.py
@@ -1,0 +1,100 @@
+#!/bin/python3
+import os
+import subprocess
+import time
+import csv
+import re
+import sys
+
+sysbench_path = os.getenv('SYSBENCH_PATH', "sysbench")
+min_pow = int(os.getenv("MIN_POW", "2"))
+target_pow = int(os.getenv("TARGET_POW", "8"))
+
+benches = sys.argv
+benches.pop(0)
+
+config = {
+    "mysql-host": os.getenv("MYSQL_HOST", "127.0.0.1"),
+    "mysql-port": os.getenv("MYSQL_PORT", "3306"),
+    "mysql-user": os.getenv("MYSQL_USER", "root"),
+    "mysql-password": os.getenv("MYSQL_PASSWORD", ""),
+    "mysql-db": os.getenv("MYSQL_DB", "sbtest"),
+    "time": os.getenv("BENCHMARK_TIME", "600"),
+    "report-interval": os.getenv("REPORT_INTERVAL", "10"),
+    "db-driver": "mysql",
+}
+
+def run_bench(config, test):
+    with open('config', 'w', newline='') as file: 
+        config_str = ""
+        for key in config.keys():
+            config_str += "%s=%s\n" % (key, config[key])
+        file.write(config_str)
+        
+    process = subprocess.Popen([sysbench_path, "--config-file=config", test,"--tables=32","--table-size=1000000","--db-ps-mode=auto","--rand-type=uniform", "run"],
+                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    
+    final_data = None
+    error = False
+    while True:
+        out = process.stdout.readline()
+        if not out: break
+        string = out.decode('utf-8').strip()
+        if string.startswith('['): print(string)
+        if string.startswith('FATAL'): 
+            print("\033[91m%s\033[0m" % string) 
+            error = True
+        if string == "SQL statistics:": break
+        
+        
+    if error: raise Exception("\033[91mSysbench exit with error.\033[0m")
+        
+    string = "".join(iter(lambda: process.stdout.readline().decode('utf-8'), ""))
+    non_spaced = string.replace(' ','')
+    
+    total_time = float(re.findall("(?<=totaltime:)[0-9.]*",non_spaced)[0])
+    
+    parsed_data = {
+        "tps": round(float(re.findall(r"(?<=transactions:)[0-9.]*", non_spaced)[0]) / total_time, 2),
+        "qps": round(float(re.findall(r"(?<=queries:)[0-9.]*", non_spaced)[0]) / total_time, 2), 
+        "qpf": {
+            "read": int(re.findall(r"(?<=read:)[0-9.]*", non_spaced)[0]), 
+            "write": int(re.findall(r"(?<=write:)[0-9.]*", non_spaced)[0]) ,
+            "other": int(re.findall(r"(?<=other:)[0-9.]*", non_spaced)[0]), 
+            "total": int(re.findall(r"(?<=total:)[0-9.]*", non_spaced)[0]),
+        }, 
+        "lat": float(re.findall(r"(?<=95thpercentile:)[0-9.]*", non_spaced)[0]), 
+        "err": int(re.findall(r"(?<=ignorederrors:)[0-9]*", non_spaced)[0]), 
+        "reconn": int(re.findall(r"(?<=reconnects:)[0-9]*", non_spaced)[0]),
+        "events": float(re.findall(r"(?<=events\(avg/stddev\):)[0-9.]*", non_spaced)[0]), 
+        "exectime": float(re.findall(r"(?<=executiontime\(avg/stddev\):)[0-9.]*", non_spaced)[0])
+    }
+
+    return parsed_data
+
+
+if __name__ == "__main__":
+    for bench in benches:
+        results = []
+        
+        for i in range(min_pow, target_pow + 1):
+            print("Benchmarking %s with %d threads..." % (bench,pow(2,i)))
+            config["threads"] = str(pow(2,i))
+            results.append((pow(2,i), run_bench(config, bench)))
+
+        
+        with open('results-%s.csv' % bench, 'w', newline='') as csvfile:
+            writer = csv.writer(csvfile)
+            writer.writerow(['threads','Transactions per second', 'Queries per second', 'Queries performed', 'Read queries performed','Write queries performed','Other queries performed', 'Latency(95%)', 'Ignored errors/s', 'Reconnects/s','Events(Threads fairness)', 'Execution time(Threads fairness)'])
+            
+            for (threads, res) in results:
+                writer.writerow([threads,res["tps"], res["qps"], 
+                                 res["qpf"]["total"], 
+                                 res["qpf"]["read"], 
+                                 res["qpf"]["write"], 
+                                 res["qpf"]["other"], 
+                                 res["lat"], 
+                                 res["err"], 
+                                 res["reconn"],
+                                 res["events"],
+                                 res["exectime"]])


### PR DESCRIPTION
队伍名 Nests

## 编译

OS: Debian GNU/Linux 12 (bookworm) x86_64
Kernel: 6.1.0-21-amd64
Go：go version go1.22.6 linux/amd64
GCC：riscv64-unknown-elf-gcc 13.2.0 / [Xuantie-900-gcc-linux-6.6.0-glibc-x86_64-V2.10.1](https://www.xrvm.cn/community/download?id=4333581795569242112)

```shell
$ git clone https://github.com/hanbings/rvspoc-S2427-tidb.git
$ cd rvspoc-S2427-tidb
$ sudo apt-get install gcc-riscv64-linux-gnu
$ GOOS=linux GOARCH=riscv64 CC=riscv64-linux-gnu-gcc make server
```

## Sysbench 测试

说明：Sysbench 使用了 LuaJIT，而 LuaJIT 在上游中的 RISCV 版本并未稳定，我们并未在 RISCV 架构中成功运行 Sysbench 软件。因此为了最低延迟，我们 [从 Sysbench 签出代码](https://github.com/akopytov/sysbench/commit/de18a036cc65196b1a4966d305f33db3d8fa6f8e) 并在同上编译步骤中使用本地的机器（x86）编译并上传至开发机的跳板机（x86）中进行测试。

依据 TiDB 官方文档中的 [Sysbench 测试部分](https://docs.pingcap.com/zh/tidb/stable/benchmark-tidb-using-sysbench)，我们使用以下指令测试了 TiDB 在 Point Select、Update Index 和 Read Only 的性能，其中数据导入仅进行一次导入并在全部测试中使用同一个数据集，预热步骤可以选做（预热需要一定的时间，如果不进行预热步骤请在所有的测试中均不使用预热）

**config**
[文件已附带于提交中](https://github.com/hanbings/rvspoc-S2427-tidb/blob/master/config)

```shell
mysql-host=127.0.0.1
mysql-port=4000
mysql-user=root
mysql-password=
mysql-db=sbtest
time=600
threads=16
report-interval=10
db-driver=mysql
```

```shell
# 数据导入
sysbench --config-file=config oltp_point_select --tables=32 --table-size=1000000 prepare
# 数据预热
sysbench --config-file=config oltp_point_select --tables=32 --table-size=1000000 prewarm

# Point select 测试
sysbench --config-file=config oltp_point_select --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
# Update index 测试
sysbench --config-file=config oltp_update_index --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
# Read-only 测试
sysbench --config-file=config oltp_read_only --tables=32 --table-size=1000000 --db-ps-mode=auto --rand-type=uniform run
```

## SG2042 / Pioneer Box

下面是使用不同编译器和参数的 TiDB 运行在 RVBox 12 或 RVBox 13 的 Sysbench 测试结果。

[RVBox12 gcc-riscv64-linux-gnu 编译器（默认参数）](https://github.com/hanbings/rvspoc-S2427-tidb/blob/master/sysbench-reports/rvbox12-gcc-riscv64-linux-gnu.md)
[RVBox13 gcc-riscv64-linux-gnu 编译器（默认参数）](https://github.com/hanbings/rvspoc-S2427-tidb/blob/master/sysbench-reports/rvbox13-gcc-riscv64-linux-gnu.md)
[RVBox13 gcc-riscv64-linux-gnu 编译器（-mtune=thead-c906）](https://github.com/hanbings/rvspoc-S2427-tidb/blob/master/sysbench-reports/rvbox13-gcc-riscv64-linux-gnu-mtune%3Dthead-c906.md)
[RVBox13 gcc-riscv64-linux-gnu 编译器（-march=rv64gcv_zfh_xtheadba_xtheadcondmov_xtheadmac）](https://github.com/hanbings/rvspoc-S2427-tidb/blob/master/sysbench-reports/rvbox13-gcc-riscv64-linux-gnu-march%3Drv64gcv_zfh_xtheadba_xtheadcondmov_xtheadmac.md)
[RVBox13 Xuantie-900-gcc-linux-6.6.0-glibc-x86_64-V2.10.1 编译器（rv64imafdcv0p7_zfh_xtheadc）](https://github.com/hanbings/rvspoc-S2427-tidb/blob/master/sysbench-reports/rvbox13-Xuantie-900-gcc-linux-6.6.0-glibc-x86_64-V2.10.1-rv64imafdcv0p7_zfh_xtheadc.md)


---

请确认勾选以下复选框，声明本人已知悉对应的提交要求。
(Please make sure to check the following box to declare that I am aware of the corresponding submission requirements.)

- [x] 本人已完整阅读并确认同意了本赛题的最新提交要求
      (I have read in full and confirm that I agree to the latest Submission Requirements for this challenge),
      [本赛题最新提交要求(The latest Submission Requirements)](https://rvspoc.org/S2427/#提交说明)


RISC-V 软件移植及优化锦标赛

RISC-V Software Porting and Optimization Championship
